### PR TITLE
Terminal scroll fixes and terminal QoL (#58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "typescript": "5.1.6"
   },
   "engines": {
-    "node": "18.x",
-    "pnpm": "8.x"
+    "node": "18.x"
   },
   "dependencies": {
     "crypto-js": "^4.2.0",

--- a/packages/client/.prettierrc
+++ b/packages/client/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "plugins": ["prettier-plugin-solidity"],
   "printWidth": 120,
   "semi": true,
   "tabWidth": 2,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,10 +1,10 @@
-import { setup } from "./mud/setup";
-import mudConfig from "contracts/mud.config";
+import { setup } from './mud/setup';
+import mudConfig from 'contracts/mud.config';
 import { LitTerminal } from './lit/lit-term';
 import './lit/lit-term';
 import './styles/setupStyles';
-import './lit/wallet/lit-wallet'
-import { setupThree, updateScene } from "./three";
+import './lit/wallet/lit-wallet';
+import { setupThree, updateScene } from './three';
 
 const {
   components,
@@ -40,24 +40,27 @@ function runCmd(cmd: string[]): void {
   let _ = processCommand(cmd, playerId);
 }
 
-// 
+//
 setupThree();
 components.Output.update$.subscribe((update) => {
   const [nextValue, prevValue] = update.value;
   if (nextValue.playerId == playerId) {
-    console.log("Output updated", update, { nextValue, prevValue });
+    console.log('Output updated', update, { nextValue, prevValue });
     if (textInput) {
       if (Array.isArray((textInput as LitTerminal).history)) {
         (textInput as LitTerminal).history = [...(textInput as LitTerminal).history, nextValue.text];
       }
     }
     updateScene(nextValue.text);
+    setTimeout(() => {
+      (textInput as LitTerminal).scrollToBottom();
+    }, 1);
   }
 });
 
 // https://vitejs.dev/guide/env-and-mode.html
 if (import.meta.env.DEV && import.meta.env.VITE_MUD_DEV_DISPLAY) {
-  const { mount: mountDevTools } = await import("@latticexyz/dev-tools");
+  const { mount: mountDevTools } = await import('@latticexyz/dev-tools');
   mountDevTools({
     config: mudConfig,
     publicClient: network.publicClient,

--- a/packages/client/src/lit/lit-term.ts
+++ b/packages/client/src/lit/lit-term.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css } from 'lit';
-import termStyle from "../styles/termStyle";
+import termStyle from '../styles/termStyle';
+import { ref, createRef } from 'lit/directives/ref.js';
 
 export class LitTerminal extends LitElement {
   declare inputValue: string;
@@ -8,37 +9,41 @@ export class LitTerminal extends LitElement {
   static get properties() {
     return {
       inputValue: { type: String },
-      history: {type: Array},
-      headerText: {type: Array}
+      history: { type: Array },
+      headerText: { type: Array },
     };
   }
+  terminalElement = createRef<HTMLDivElement>();
+  terminalInputElement = createRef<HTMLInputElement>();
+  // @query(".terminal") terminalElement;
 
   constructor() {
     super();
-    this.inputValue = '> '; // Initialize your property
+    this.inputValue = ''; // Initialize your property
     // @ts-ignore
-    this.history = [
-      "\n"
-    ];
+    this.history = ['\n'];
     this.headerText = [
-      "Archetypal Tech welcomes you to DEATH"
-      , "well possibly..."
-      , "\n"
-      , "The O'Ruggin Trail, no:23"
-      , "from the good folk at"
+      'Archetypal Tech welcomes you to DEATH',
+      'well possibly...',
+      '\n',
+      "The O'Ruggin Trail, no:23",
+      'from the good folk at',
     ];
   }
 
   // @ts-ignore
   static styles = css([termStyle]);
+  static inputHistory: Array<string> = [];
+  static inputHistoryIndex = 0;
+  static inputHistoryOriginalInput = '';
 
   render() {
     return html`
-      <div class="terminal">
-        ${this.headerText.map(line => html`<div class="headerOutput">${line}</div>`)}
+      <div class="terminal" ${ref(this.terminalElement)} @click="${this.focusOnInput}">
+        ${this.headerText.map((line) => html`<div class="headerOutput">${line}</div>`)}
         <div class="bastard"><b>B</b>est <b>A</b>rchetypal <b>S</b>ystem <b>T</b>erminals <b>A</b>nd <b>R</b>etrograde <b>D</b>evices</div>
-        ${this.history.map(line => html`<div class="output">${line}</div>`)}
-        <input type="text" .value="${this.inputValue}"
+        ${this.history.map((line) => html`<div class="output">${line}</div>`)}
+        <span>&#x3e; </spawn><input type="text" .value="${this.inputValue}" ${ref(this.terminalInputElement)}
                   @keydown="${this.handleEnter}"
                   @input=${this.handleInput}>
       </div>
@@ -50,30 +55,81 @@ export class LitTerminal extends LitElement {
     const elem = e.target as EventTarget;
     let newVal = input.value;
     // @ts-ignore
-    if (this.inputValue === newVal && this.inputValue !== (elem as HTMLInputElement ).value) {
+    if (this.inputValue === newVal && this.inputValue !== (elem as HTMLInputElement).value) {
       (elem as HTMLInputElement).value = this.inputValue;
     } else {
       this.inputValue = newVal;
     }
   }
 
+  private focusOnInput(e: Event) {
+    this.terminalInputElement.value.focus();
+  }
+
+  public scrollToBottom() {
+    if (this.terminalElement) {
+      this.terminalElement.value.scrollTo(
+        0,
+        this.terminalElement.value.scrollHeight,
+        // smooth
+        { behavior: 'smooth' }
+      );
+    }
+  }
+
   private stripCommandString(s: string) {
-    let seq = "> ";
-    return s.replace(seq, "");
+    let seq = '> ';
+    return s.replace(seq, '');
   }
 
   private handleEnter(e: KeyboardEvent) {
     if (e.key === 'Enter') {
       const commandStr = this.stripCommandString(this.inputValue);
-      this.dispatchEvent(new CustomEvent('command-update', {
-        detail: { value: commandStr },
-        bubbles: true, // Allows the event to bubble up through the DOM
-        composed: true // Allows the event to cross the shadow DOM boundary
-      }));
-      this.history = [...this.history, commandStr];
-      this.inputValue = '> ';
+      this.dispatchEvent(
+        new CustomEvent('command-update', {
+          detail: { value: commandStr },
+          bubbles: true, // Allows the event to bubble up through the DOM
+          composed: true, // Allows the event to cross the shadow DOM boundary
+        })
+      );
+      this.history = [...this.history, '> ' + commandStr];
+      this.inputValue = '';
+      LitTerminal.inputHistory.push(commandStr);
+      LitTerminal.inputHistoryIndex = 0;
+      LitTerminal.inputHistoryOriginalInput = '';
+    } else if (e.key === 'ArrowUp') {
+      /* Example of how the input history up/down works
+      array index, action, inputHistoryIndex
+    ===================
+      0 look around 3
+      1 go west     2
+      2 go south    1
+      
+      > User input  0
+
+    ===================
+
+      0 look around 1
+      
+      > User input  0
+      */
+      if (LitTerminal.inputHistoryIndex === 0) {
+        LitTerminal.inputHistoryOriginalInput = this.inputValue; // store the original input
+      }
+      if (LitTerminal.inputHistoryIndex < LitTerminal.inputHistory.length) {
+        LitTerminal.inputHistoryIndex++;
+        this.inputValue = LitTerminal.inputHistory[LitTerminal.inputHistory.length - LitTerminal.inputHistoryIndex];
+      }
+    } else if (e.key === 'ArrowDown') {
+      if (LitTerminal.inputHistoryIndex > 0) {
+        LitTerminal.inputHistoryIndex--;
+        if (LitTerminal.inputHistoryIndex === 0) {
+          this.inputValue = LitTerminal.inputHistoryOriginalInput; // restore the original input
+        } else {
+          this.inputValue = LitTerminal.inputHistory[LitTerminal.inputHistory.length - LitTerminal.inputHistoryIndex];
+        }
+      }
     }
   }
-
 }
 customElements.define('l-terminal', LitTerminal);

--- a/packages/client/src/styles/termStyle.ts
+++ b/packages/client/src/styles/termStyle.ts
@@ -51,6 +51,8 @@ const cssString: string = `:host {
           margin-bottom: 4px;
           height: calc(100% - 8px);
           height: 100%;
+          overflow-y: auto;
+          scroll-behavior: smooth;
       }
 
       .output {


### PR DESCRIPTION
* Terminal/wallet repositioning

* Terminal fixed and QoL

- Removed pnpm version requirement
- Added prettierrc file to client side
- The terminal now automatically scrolls (smoothly) to the bottom of the page
- The > character can now no longer be deleted.
- Clicking anywhere inside the terminal will focus on the input box, like with most terminals.
- Added support to using the Up/Down arrow keys to switch to previously used commands. Also includes memory of the typed in command, so it's possible to go back to the originally typed input before ^ up was pressed.