### PR TITLE
Init TokenSystem on start, add grammar type and returns

### DIFF
--- a/cardinal/component/component_verbData.go
+++ b/cardinal/component/component_verbData.go
@@ -12,7 +12,7 @@ type VerbData struct {
 	Verb            enums.ActionType    // The action/verb from the command
 	DirectNoun      enums.ObjectType    // The direct object of the action
 	IndirectDirNoun enums.DirObjectType // The indirect directional object of the action
-	ObjType         string              // Type of the direct object
+	IndirectObjNoun enums.ObjectType    // The indirect Object noun
 	ErrCode         uint8               // Error code for parsing the tokens
 }
 

--- a/cardinal/constants/game_constants.go
+++ b/cardinal/constants/game_constants.go
@@ -1,0 +1,48 @@
+package constants
+
+// Define the constants for GameConstants
+const (
+	// MAX_SIZES for functions
+	MAX_TOK uint8 = 16
+	MIN_TOK uint8 = 2
+
+	// DATA_BITS for packing
+	TERRAIN_BITS uint8 = 24 // << 24
+	ROOM_BITS    uint8 = 16 // << 16
+	OBJECT_BITS  uint8 = 8  // << 8
+
+	// Direction bits
+	NORTH_DIR uint8 = 1 // 0x0001
+	EAST_DIR  uint8 = 2 // 0x0010
+	SOUTH_DIR uint8 = 4 // 0x0100
+	WEST_DIR  uint8 = 8 // 0x1000
+
+	SIZED_AR_SIZE uint32 = 32 // the max size of a Sized Array, 31 items + 1 for count
+)
+
+// Define the constants for ErrCodes
+const (
+	ER_DR_ND                        uint8 = 122 // Error DirectionRoutine DR
+	ER_DR_NOP                       uint8 = 123
+	ER_PR_ND                        uint8 = 124 // Error ParserRoutine DR
+	ER_PR_NT                        uint8 = 125
+	ER_PR_TK_CX                     uint8 = 126 // > MAX TOKS
+	ER_PR_NOP                       uint8 = 127
+	ER_PR_TK_C1                     uint8 = 128 // < MIN TOKS
+	ER_PR_NO                        uint8 = 129 // Error No DirectObject
+	ER_LK_NOP                       uint8 = 130 // Error Bad Look Command
+	ER_AR_BNDS                      uint8 = 131 // Error No DirectObject
+	ER_TKPR_NO                      uint8 = 132 // Error No DirectObject
+	ER_SIZED_AR_OUT_OF_SPACE        uint8 = 133 // when we try and add an item to a size array using the add function, but its full
+	ER_SIZED_AR_NOT_ITEMS_TO_REMOVE uint8 = 134 // when we try and remove an item to a sized array using the remove function, but noone is home!
+	ER_ACTION_HDL_NO                uint8 = 135 // Error No Objects to handle
+)
+
+// some result codes (from game commands)
+const (
+	GO_NO_EXIT uint8 = 8 // Error DirectionRoutine DR
+	// We use a custom return type for LOOK's
+	// because we cant return a 0 for no err unlike the rest of our commands
+	LK_RT   uint8 = 9
+	AH_BC_0 uint8 = 10
+)

--- a/cardinal/enums/enums.go
+++ b/cardinal/enums/enums.go
@@ -334,3 +334,30 @@ var toEnumTxDef = map[string]TxtDefType{
 	"Object":    TxtDefTypeObject,
 	"Action":    TxtDefTypeAction,
 }
+
+// GrammarType - Custom type for the gramar definition types
+type GrammarType int
+
+const (
+	GrammarTypeNone              GrammarType = iota // Starts at 0
+	GrammarTypeDefinitionArticle                    // 1
+	GrammarTypePreposition                          // 2
+	GrammarTypePrepo                                // 2
+	GrammarTypeAdverb                               // 3
+)
+
+var toStringGrammar = map[GrammarType]string{
+	GrammarTypeNone:              "None",
+	GrammarTypeDefinitionArticle: "The",
+	GrammarTypePreposition:       "To",
+	GrammarTypePrepo:             "at",
+	GrammarTypeAdverb:            "Around",
+}
+
+var toEnumGrammar = map[string]GrammarType{
+	"None":   GrammarTypeNone,
+	"The":    GrammarTypeDefinitionArticle,
+	"To":     GrammarTypePreposition,
+	"at":     GrammarTypePrepo,
+	"Around": GrammarTypeAdverb,
+}

--- a/cardinal/main.go
+++ b/cardinal/main.go
@@ -46,6 +46,7 @@ func MustInitWorld(w *cardinal.World) {
 	// NOTE: You must register your transactions here for it to be executed.
 	Must(
 		cardinal.RegisterMessage[msg.CreatePlayerMsg, msg.CreatePlayerReply](w, "create-player"),
+		cardinal.RegisterMessage[msg.ProcessCommandsMsg, msg.ProcessCommandsReply](w, "process-commands"),
 	)
 
 	// Register queries
@@ -57,12 +58,13 @@ func MustInitWorld(w *cardinal.World) {
 	// This is a neat feature that can be strategically used for systems that depends on the order of execution.
 	Must(cardinal.RegisterSystems(w,
 		system.CreatePlayerSystem,
+		system.ProcessCommandsTokens,
+		system.NTokeniserSystem,
 	))
 
 	// Register the init system when the world is initiated.
 	Must(cardinal.RegisterInitSystems(w,
 		system.NGameSetupSystem,
-		system.NTokeniserSystem,
 	))
 
 }

--- a/cardinal/main.go
+++ b/cardinal/main.go
@@ -56,13 +56,13 @@ func MustInitWorld(w *cardinal.World) {
 	// Each system executes deterministically in the order they are added.
 	// This is a neat feature that can be strategically used for systems that depends on the order of execution.
 	Must(cardinal.RegisterSystems(w,
-		//system.TokeniserSystem,
 		system.CreatePlayerSystem,
 	))
 
 	// Register the init system when the world is initiated.
 	Must(cardinal.RegisterInitSystems(w,
 		system.NGameSetupSystem,
+		system.NTokeniserSystem,
 	))
 
 }

--- a/cardinal/msg/msg_process_commands.go
+++ b/cardinal/msg/msg_process_commands.go
@@ -1,0 +1,12 @@
+package msg
+
+type ProcessCommandsMsg struct {
+	PlayerName string   `json:"PlayerName"` // Name of the player.
+	Tokens     []string `json:"Tokens"`     // Array of commands that are sent. They are of type string.
+}
+
+type ProcessCommandsReply struct {
+	Success bool   `json:"Success"` // Indicates whether the move was successful or not.
+	Message string `json:"Message"` // Optional message providing additional information.
+
+}

--- a/cardinal/system/system_meat_puppet_system.go
+++ b/cardinal/system/system_meat_puppet_system.go
@@ -1,0 +1,319 @@
+package system
+
+import (
+	"fmt"
+
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/message"
+	"pkg.world.dev/world-engine/cardinal/search/filter"
+	"pkg.world.dev/world-engine/cardinal/types"
+
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/component"
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/constants"
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/msg"
+)
+
+// Define a variable to hold the TokeniserSystem instance
+var ts *TokeniserSystem
+
+func ProcessCommandsTokens(world cardinal.WorldContext) error {
+	return cardinal.EachMessage[msg.ProcessCommandsMsg, msg.ProcessCommandsReply](
+		world,
+		func(messageData message.TxData[msg.ProcessCommandsMsg]) (msg.ProcessCommandsReply, error) {
+			playerEntity, err := findExistingPlayer(world, messageData.Msg.PlayerName)
+			if err != nil {
+				if isDevelopmentMode() {
+					logger.Errorf("\033[31mError searching for Player entity: %v\033[0m", err)
+				}
+
+				return msg.ProcessCommandsReply{
+					Success: false,
+					Message: fmt.Sprintf("Error searching for Player entity: %v", err),
+				}, err
+			}
+
+			player, err := getPlayerEntity(world, playerEntity)
+			if err != nil {
+				if isDevelopmentMode() {
+					logger.Errorf("\033[31mError getting Player: %v\033[0m", err)
+				}
+
+				return msg.ProcessCommandsReply{
+					Success: false,
+					Message: fmt.Sprintf("Error getting Player: %v", err),
+				}, err
+			}
+
+			// variables to use
+			pID := player.PlayerID
+			// rID := player.RoomID ---> Not used YET
+			var tokens = messageData.Msg.Tokens
+			if isDevelopmentMode() {
+				logger.Infof("\033[33mTokens are: %v\033[0m", tokens)
+			}
+			var er uint8
+			var move bool
+			//var nxt uint32 ---> Not used YET
+
+			ts = NewTokeniserSystem()
+
+			if uint8(len(tokens)) > constants.MAX_TOK { // Check length of the tokens againts the max number.
+				er = constants.ER_PR_TK_CX
+			}
+
+			var tok1 string
+			tok1 = tokens[0]
+			if isDevelopmentMode() {
+				logger.Debugf("\033[35m---->CMD: %s\033[0m", tok1)
+			}
+			tokD := ts.GetDirectionType(tok1)
+
+			if tokD != enums.DirectionTypeNone {
+				move = true
+				if isDevelopmentMode() {
+					logger.Infof("\033[35m---->1-HERE GOES GET NEXT ROOM - DIRECTION SYSTEM\033[0m")
+				}
+				// HERE GOES GET NEXT ROOM - DIRECTION SYSTEM
+			} else if ts.GetActionType(tok1) != enums.ActionTypeNone {
+				if uint8(len(tokens)) >= constants.MIN_TOK {
+					if isDevelopmentMode() {
+						logger.Debugf("\033[35m---->tok.len %d\033[0m", len(tokens))
+					}
+
+					if ts.GetActionType(tok1) == enums.ActionTypeGo {
+						// GO: form
+						move = true
+						// HERE GOES GET NEXT ROOM - DIRECTION SYSTEM
+						if isDevelopmentMode() {
+							logger.Infof("\033[35m---->2-HERE GOES GET NEXT ROOM - DIRECTION SYSTEM\033[0m")
+						}
+					} else {
+						// VERB: form
+						er = handleVerb(tokens, pID)
+						move = false
+					}
+
+				} else {
+					er = handleAlias(tokens, pID)
+					move = false
+				}
+			} else {
+				er = constants.ER_PR_NOP
+			}
+
+			// we have gone through the TOKENS, give err feedback if needed
+			if er != 0 {
+				if isDevelopmentMode() {
+					logger.Errorf("\033[31m---->PCR_ERR: %v:\033[0m", er)
+				}
+				var errMsg string
+				errMsg = insultMeat(er, "")
+				// HERE GOES OUTPUT SET
+				return msg.ProcessCommandsReply{
+					Success: false,
+					Message: fmt.Sprintf("%v", errMsg),
+				}, err
+			} else {
+				// either a do something or move rooms command
+				if move {
+					// Here Goes Enter Room
+					if isDevelopmentMode() {
+						logger.Infof("\033[35m---->GOING TO ROOM\033[0m")
+					}
+				} else {
+					// hit look libs_ perhaps?
+					if isDevelopmentMode() {
+						logger.Infof("\033[35m---->hit look libs_ perhaps?\033[0m")
+					}
+				}
+			}
+
+			if isDevelopmentMode() {
+				logger.Infof("\033[32mProcessing tokens completed\033[0m")
+			}
+
+			ts.FishTokens(tokens)
+
+			return msg.ProcessCommandsReply{
+				Success: true,
+				Message: "Processing tokens completed",
+			}, nil
+
+		},
+	)
+}
+
+func getPlayerEntity(world cardinal.WorldContext, pEID types.EntityID) (component.Player, error) {
+	var exisingPlayer component.Player
+	err := cardinal.NewSearch().Entity(filter.Exact(filter.Component[component.Player]())).
+		Each(world, func(id types.EntityID) bool {
+			player, err := cardinal.GetComponent[component.Player](world, id)
+			if err != nil {
+				if isDevelopmentMode() {
+					logger.Errorf("\033[31mError getting Player Component: %v\033[0m", err)
+				}
+				return true
+
+			}
+
+			if player.PlayerID == uint32(pEID) {
+				exisingPlayer = *player
+				return false
+			}
+
+			return true
+		})
+
+	return exisingPlayer, err
+}
+
+func handleAlias(tokens []string, playerID uint32) (err uint8) {
+	vrb := ts.GetActionType(tokens[0])
+	var e uint8
+	if vrb == enums.ActionTypeInventory {
+		// HERE GOES INVENTORY FROM INVENTORY SYSTEM
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE ALIAS: NOW SHOULD BE GOING TO INVENTORY FROM INVENTORY SYSTEM\033[0m")
+		}
+		e = 0
+	} else if vrb == enums.ActionTypeLook {
+		// HERE GOES STUFF FROM LOOK SYSTEM
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE ALIAS: NOW SHOULD BE GOING TO STUFF FROM LOOK SYSTEM\033[0m")
+		}
+		e = 0
+	}
+	return e
+}
+
+func handleVerb(tokens []string, playerID uint32) (err uint8) {
+	vrb := ts.GetActionType(tokens[0])
+	var e uint8
+	var resultStr string
+
+	//cmdData := ts.FishTokens(tokens) ---> Not used YET
+	if vrb == enums.ActionTypeLook || vrb == enums.ActionTypeDescribe {
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE VERB: NOW SHOULD BE GOING TO STUFF FROM LOOK SYSTEM\033[0m")
+		}
+		e = 0
+	} else if vrb == enums.ActionTypeTake {
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE VERB: NOW SHOULD BE GOING TO TAKE FROM INVENTORY SYSTEM\033[0m")
+		}
+		e = 0
+	} else if vrb == enums.ActionTypeDrop {
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE VERB: NOW SHOULD BE GOING TO DROP FROM INVENTORY SYSTEM\033[0m")
+		}
+		e = 0
+	} else {
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE VERB: NOW SHOULD BE GOING TO ACT FROM ACTION SYSTEM\033[0m")
+		}
+		e, resultStr = 0, "testing"
+		if isDevelopmentMode() {
+			logger.Infof("\033[35m---->HANDLE VERB:resultStr: %s\033[0m", resultStr)
+		}
+	}
+	return e
+}
+
+func insultMeat(cErr uint8, badCmd string) string {
+	var eMsg string
+	if cErr == constants.ER_PR_TK_CX {
+		eMsg = "WTF, slow down cowboy, your gonna hurt yourself"
+	} else if cErr == constants.ER_PR_NOP || cErr == constants.ER_PR_TK_C1 {
+		eMsg = "Nope, gibberish\n" +
+			"Stop breathing with your mouth."
+	} else if cErr == constants.ER_PR_ND || cErr == constants.ER_DR_ND {
+		eMsg = "Go where pilgrim?"
+	} else if cErr == constants.ER_DR_NOP {
+		eMsg = "Go " + badCmd + " is nowhere I know of bellend"
+	} else if cErr == constants.GO_NO_EXIT {
+		eMsg = "Can't go that away " + badCmd
+	}
+	return eMsg
+}
+
+func ProcessCommandsTokens2(Tokens []string, PlayerID uint32) error {
+	pID := PlayerID
+	// rID := player.RoomID ---> Not used YET
+	tokens := Tokens
+	var er uint8
+	var move bool
+	//var nxt uint32 ---> Not used YET
+
+	if uint8(len(tokens)) > constants.MAX_TOK {
+		er = constants.ER_PR_TK_CX
+	}
+
+	var tok1 string
+	tok1 = tokens[0]
+	if isDevelopmentMode() {
+		logger.Debugf("\033[35m---->CMD: %s\033[0m", tok1)
+	}
+	tokD := ts.GetDirectionType(tok1)
+
+	if tokD != enums.DirectionTypeNone {
+		move = true
+		// HERE GOES GET NEXT ROOM - DIRECTION SYSTEM
+	} else if ts.GetActionType(tok1) != enums.ActionTypeNone {
+		if uint8(len(tokens)) >= constants.MIN_TOK {
+			if isDevelopmentMode() {
+				logger.Debugf("\033[35m---->tok.len %d\033[0m", len(tokens))
+			}
+
+			if ts.GetActionType(tok1) == enums.ActionTypeGo {
+				// GO: form
+				move = true
+				// HERE GOES GET NEXT ROOM - DIRECTION SYSTEM
+			} else {
+				// VERB: form
+				er = handleVerb(tokens, pID)
+				move = false
+			}
+
+		} else {
+			er = handleAlias(tokens, pID)
+			move = false
+		}
+	} else {
+		er = constants.ER_PR_NOP
+	}
+
+	// we have gone through the TOKENS, give err feedback if needed
+	if er != 0 {
+		if isDevelopmentMode() {
+			logger.Errorf("\033[31m---->PCR_ERR: %v:\033[0m", er)
+		}
+		var errMsg string
+		errMsg = insultMeat(er, "")
+		// HERE GOES OUTPUT SET
+		if isDevelopmentMode() {
+			logger.Debugf("\033[35m---->err message is: %s\033[0m", errMsg)
+		}
+		return nil
+	} else {
+		// either a do something or move rooms command
+		if move {
+			// Here Goes Enter Room
+			if isDevelopmentMode() {
+				logger.Infof("\033[35m---->GOING TO ROOM\033[0m")
+			}
+		} else {
+			// hit look libs_ perhaps?
+			if isDevelopmentMode() {
+				logger.Infof("\033[35m---->hit look libs_ perhaps?\033[0m")
+			}
+		}
+	}
+
+	if isDevelopmentMode() {
+		logger.Infof("\033[32mProcessing tokens completed\033[0m")
+	}
+
+	return nil
+
+}

--- a/cardinal/system/system_tokeniser.go
+++ b/cardinal/system/system_tokeniser.go
@@ -1,16 +1,14 @@
 package system
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/component"
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/constants"
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
 	"pkg.world.dev/world-engine/cardinal"
 )
 
 func NTokeniserSystem(world cardinal.WorldContext) error {
-	NewTokeniserSystem()
+
 	return nil
 }
 
@@ -44,6 +42,7 @@ func (ts *TokeniserSystem) initLUTS() {
 	ts.setupObjects()
 	ts.setupDirs()
 	ts.setupDirObjs()
+	ts.setupGrammar()
 	ts.setupVrbAct()
 }
 
@@ -110,57 +109,61 @@ func (ts *TokeniserSystem) setupVrbAct() {
 
 // setupGrammar initializes the grammar response tookup table with predifined grammar
 func (ts *TokeniserSystem) setupGrammar() {
-	ts.grammarLookup["The"] = enums.GrammarTypeDefinitionArticle
-	ts.grammarLookup["To"] = enums.GrammarTypePreposition
-	ts.grammarLookup["at"] = enums.GrammarTypePrepo
+	ts.grammarLookup["THE"] = enums.GrammarTypeDefinitionArticle
+	ts.grammarLookup["TO"] = enums.GrammarTypePreposition
+	ts.grammarLookup["AT"] = enums.GrammarTypePrepo
 	ts.grammarLookup["Around"] = enums.GrammarTypeAdverb
 }
 
 // FishTokens processes the tokenized command and returns VerbData
 func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	var data component.VerbData // Initialize VerbData to store the result
-	var err uint8               // Error code variable
+	var err uint8 = 0           // Error code variable
 	lenTokens := len(tokens) - 1
 
 	// Look up the verb, object, and directional object from the tokens
-	vrb, vrbExists := ts.cmdLookup[strings.ToUpper(tokens[0])]
-	obj, objExists := ts.objLookup[strings.ToUpper(tokens[lenTokens])]
-	dobj, dobjExists := ts.dirObjLookup[strings.ToUpper(tokens[lenTokens])]
-
-	if !vrbExists {
-		// Handle the case where the verb lookup fails
-		fmt.Printf("Error: Verb '%s' not recognized\n", tokens[0])
-		data.ErrCode = 1 // Set an appropriate error code
-		return data
-	}
+	var vrb enums.ActionType = ts.cmdLookup[(tokens[0])]
+	var obj enums.ObjectType = ts.objLookup[(tokens[lenTokens])]
+	var dobj enums.DirObjectType = ts.dirObjLookup[(tokens[lenTokens])]
 
 	data.Verb = vrb // Set the verb in VerbData
-	if !objExists && !dobjExists {
-		data.ErrCode = 1 // Set error code if no object or directional object is found
-		return data
-	}
-
-	// Handle cases where the object exists and the token length is less than or equal to 3
-	if objExists && len(tokens) <= 3 {
-		data.DirectNoun = obj
-	} else if !objExists {
-		err = 1 // Set error code if no object exists
-	}
-
-	// Handle cases where the token length is greater than 3
-	if len(tokens) > 3 {
-		if dobjExists {
-			// Look for object in the second or third token if directional object exists
-			obj, objExists = ts.objLookup[strings.ToUpper(tokens[1])]
-			if !objExists {
-				obj, objExists = ts.objLookup[strings.ToUpper(tokens[2])]
-				if !objExists {
-					err = 1 // Set error code if no object is found
-				}
+	if obj == enums.ObjectTypeNone && dobj == enums.DirObjectTypeNone {
+		data.ErrCode = constants.ER_TKPR_NO
+		if isDevelopmentMode() {
+			logger.Errorf("\033[31mE--->1err:%d\033[0m", data.ErrCode)
+		}
+	} else {
+		// ? VRB, OBJ ? //
+		if obj != enums.ObjectTypeNone && len(tokens) <= 3 {
+			data.DirectNoun = obj
+		} else if obj == enums.ObjectTypeNone && len(tokens) <= 3 {
+			err = constants.ER_TKPR_NO
+			if isDevelopmentMode() {
+				logger.Errorf("\033[31mE--->2err:%d\033[0m", err)
 			}
-		} else if objExists {
-			// Return early if dealing with a form where the second object is not a directional object
-			return data
+		}
+		if len(tokens) > 3 {
+			// ? VRB, [DA], OBJ, IOBJ ? //
+			// dirObj ?
+			if dobj != enums.DirObjectTypeNone {
+				// we have IOBJ find DOBJ
+				obj = ts.objLookup[tokens[1]]
+				if obj == enums.ObjectTypeNone {
+					obj = ts.objLookup[tokens[2]]
+					if obj == enums.ObjectTypeNone {
+						err = constants.ER_TKPR_NO
+						if isDevelopmentMode() {
+							logger.Errorf("\033[31mE--->3err:%d\033[0m", err)
+						}
+					}
+				}
+			} else if obj != enums.ObjectTypeNone {
+				// we arent dealing with this type structure right now
+				// but we have a "throw thing1 at thing2" form where thing2
+				// is not a direction object. Probably combat as it goes
+				// so for now return
+				return data
+			}
 		}
 	}
 
@@ -168,7 +171,10 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	data.DirectNoun = obj
 	data.IndirectDirNoun = dobj
 	data.ErrCode = err
-	fmt.Printf("--->d.dobj:%s iobj:%s vrb:%s\n", data.DirectNoun, data.IndirectDirNoun, data.Verb)
+	//fmt.Printf("--->d.dobj:%s iobj:%s vrb:%s\n", data.DirectNoun, data.IndirectDirNoun, data.Verb)
+	if isDevelopmentMode() {
+		logger.Infof("\033[34mP--->d.dobj:%s iobj:%s vrb:%s\033[0m", data.DirectNoun, data.IndirectDirNoun, data.Verb)
+	}
 	return data
 }
 

--- a/cardinal/system/system_tokeniser.go
+++ b/cardinal/system/system_tokeniser.go
@@ -6,7 +6,13 @@ import (
 
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/component"
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+	"pkg.world.dev/world-engine/cardinal"
 )
+
+func NTokeniserSystem(world cardinal.WorldContext) error {
+	NewTokeniserSystem()
+	return nil
+}
 
 // TokeniserSystem structure
 type TokeniserSystem struct {
@@ -14,6 +20,7 @@ type TokeniserSystem struct {
 	dirLookup      map[string]enums.DirectionType          // Lookup table for direction strings to DirectionType
 	dirObjLookup   map[string]enums.DirObjectType          // Lookup table for direction object strings to DirObjectType
 	objLookup      map[string]enums.ObjectType             // Lookup table for object strings to ObjectType
+	grammarLookup  map[string]enums.GrammarType            // Lookup table for GrammarType
 	responseLookup map[enums.ActionType][]enums.ActionType // Lookup table for action responses
 }
 
@@ -24,6 +31,7 @@ func NewTokeniserSystem() *TokeniserSystem {
 		dirLookup:      make(map[string]enums.DirectionType),
 		dirObjLookup:   make(map[string]enums.DirObjectType),
 		objLookup:      make(map[string]enums.ObjectType),
+		grammarLookup:  make(map[string]enums.GrammarType),
 		responseLookup: make(map[enums.ActionType][]enums.ActionType),
 	}
 	ts.initLUTS()
@@ -100,6 +108,14 @@ func (ts *TokeniserSystem) setupVrbAct() {
 	ts.responseLookup[enums.ActionTypeBreak] = []enums.ActionType{enums.ActionTypeBreak}
 }
 
+// setupGrammar initializes the grammar response tookup table with predifined grammar
+func (ts *TokeniserSystem) setupGrammar() {
+	ts.grammarLookup["The"] = enums.GrammarTypeDefinitionArticle
+	ts.grammarLookup["To"] = enums.GrammarTypePreposition
+	ts.grammarLookup["at"] = enums.GrammarTypePrepo
+	ts.grammarLookup["Around"] = enums.GrammarTypeAdverb
+}
+
 // FishTokens processes the tokenized command and returns VerbData
 func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	var data component.VerbData // Initialize VerbData to store the result
@@ -154,4 +170,29 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	data.ErrCode = err
 	fmt.Printf("--->d.dobj:%s iobj:%s vrb:%s\n", data.DirectNoun, data.IndirectDirNoun, data.Verb)
 	return data
+}
+
+// GetResponseForVerb returns the response actions for a given verb
+func (ts *TokeniserSystem) GetResponseForVerb(key enums.ActionType) []enums.ActionType {
+	return ts.responseLookup[key]
+}
+
+// GetObjectType returns the ObjectType for a given object key
+func (ts *TokeniserSystem) GetObjectType(key string) enums.ObjectType {
+	return ts.objLookup[key]
+}
+
+// GetActionType returns the ActionType for a given action key
+func (ts *TokeniserSystem) GetActionType(key string) enums.ActionType {
+	return ts.cmdLookup[key]
+}
+
+// GetGrammarType returns the GrammarType for a given grammar key
+func (ts *TokeniserSystem) GetGrammarType(key string) enums.GrammarType {
+	return ts.grammarLookup[key]
+}
+
+// GetDirectionType returns the DirectionType for a given direction key
+func (ts *TokeniserSystem) GetDirectionType(key string) enums.DirectionType {
+	return ts.dirLookup[key]
 }

--- a/cardinal/system/t_meat_puppet_systemt_test.go
+++ b/cardinal/system/t_meat_puppet_systemt_test.go
@@ -1,0 +1,207 @@
+package system
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/constants"
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+	"github.com/stretchr/testify/assert"
+)
+
+// Define the interface
+type Tokeniser interface {
+	GetDirectionType(token string) enums.DirectionType
+	GetActionType(token string) enums.ActionType
+}
+
+// Mock implementation of the Tokeniser interface
+type MockTokeniserSystem struct{}
+
+func (m *MockTokeniserSystem) GetDirectionType(token string) enums.DirectionType {
+	switch token {
+	case "North":
+		return enums.DirectionTypeNorth
+	default:
+		return enums.DirectionTypeNone
+	}
+}
+
+func (m *MockTokeniserSystem) GetActionType(token string) enums.ActionType {
+	switch token {
+	case "Go":
+		return enums.ActionTypeGo
+	case "Look":
+		return enums.ActionTypeLook
+	case "Take":
+		return enums.ActionTypeTake
+	case "Drop":
+		return enums.ActionTypeDrop
+	default:
+		return enums.ActionTypeNone
+	}
+}
+
+// Ensure TokeniserSystem implements Tokeniser
+var _ Tokeniser = (*TokeniserSystem)(nil)
+
+// Test for ProcessCommandsTokens2
+func TestProcessCommandsTokens2(t *testing.T) {
+	ts = &TokeniserSystem{} // Set the global ts to our mock
+
+	tests := []struct {
+		tokens      []string
+		playerID    uint32
+		expectedErr error
+	}{
+		{
+			tokens:      []string{"Go", "North"},
+			playerID:    1,
+			expectedErr: nil,
+		},
+		{
+			tokens:      []string{"Look"},
+			playerID:    1,
+			expectedErr: nil,
+		},
+		{
+			tokens:      []string{"Take", "Key"},
+			playerID:    1,
+			expectedErr: nil,
+		},
+		{
+			tokens:      []string{"InvalidCommand"},
+			playerID:    1,
+			expectedErr: nil, // Assuming no actual error is returned
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.tokens), func(t *testing.T) {
+			// Call the function with test data
+			err := ProcessCommandsTokens2(test.tokens, test.playerID)
+
+			// Check the error
+			assert.Equal(t, test.expectedErr, err)
+		})
+	}
+}
+
+// Test for handleAlias
+func TestHandleAlias(t *testing.T) {
+	ts = &TokeniserSystem{} // Set the global ts to our mock
+
+	tests := []struct {
+		tokens      []string
+		playerID    uint32
+		expectedErr uint8
+	}{
+		{
+			tokens:      []string{"Inventory"},
+			playerID:    1,
+			expectedErr: 0,
+		},
+		{
+			tokens:      []string{"Look"},
+			playerID:    1,
+			expectedErr: 0,
+		},
+		{
+			tokens:      []string{"InvalidCommand"},
+			playerID:    1,
+			expectedErr: 0, // Assuming the default behavior is no error
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.tokens), func(t *testing.T) {
+			// Call the function with test data
+			err := handleAlias(test.tokens, test.playerID)
+
+			// Check the error code
+			assert.Equal(t, test.expectedErr, err)
+		})
+	}
+}
+
+// Test for handleVerb
+func TestHandleVerb(t *testing.T) {
+	ts = &TokeniserSystem{} // Set the global ts to our mock
+
+	tests := []struct {
+		tokens      []string
+		playerID    uint32
+		expectedErr uint8
+	}{
+		{
+			tokens:      []string{"Look"},
+			playerID:    1,
+			expectedErr: 0,
+		},
+		{
+			tokens:      []string{"Take"},
+			playerID:    1,
+			expectedErr: 0,
+		},
+		{
+			tokens:      []string{"Drop"},
+			playerID:    1,
+			expectedErr: 0,
+		},
+		{
+			tokens:      []string{"InvalidCommand"},
+			playerID:    1,
+			expectedErr: 0, // Assuming the default behavior is no error
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.tokens), func(t *testing.T) {
+			// Call the function with test data
+			err := handleVerb(test.tokens, test.playerID)
+
+			// Check the error code
+			assert.Equal(t, test.expectedErr, err)
+		})
+	}
+}
+
+// Test for insultMeat
+func TestInsultMeat(t *testing.T) {
+	tests := []struct {
+		cErr        uint8
+		badCmd      string
+		expectedMsg string
+	}{
+		{
+			cErr:        constants.ER_PR_TK_CX,
+			badCmd:      "",
+			expectedMsg: "WTF, slow down cowboy, your gonna hurt yourself",
+		},
+		{
+			cErr:        constants.ER_PR_NOP,
+			badCmd:      "",
+			expectedMsg: "Nope, gibberish\nStop breathing with your mouth.",
+		},
+		{
+			cErr:        constants.ER_DR_NOP,
+			badCmd:      "North",
+			expectedMsg: "Go North is nowhere I know of bellend",
+		},
+		{
+			cErr:        constants.GO_NO_EXIT,
+			badCmd:      "East",
+			expectedMsg: "Can't go that away East",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.cErr), func(t *testing.T) {
+			// Call the function with test data
+			msg := insultMeat(test.cErr, test.badCmd)
+
+			// Check the output message
+			assert.Equal(t, test.expectedMsg, msg)
+		})
+	}
+}

--- a/cardinal/system/t_tokeniser_system_test.go
+++ b/cardinal/system/t_tokeniser_system_test.go
@@ -1,0 +1,81 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTokeniserSystem(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	assert.NotNil(t, ts.cmdLookup)
+	assert.NotNil(t, ts.dirLookup)
+	assert.NotNil(t, ts.dirObjLookup)
+	assert.NotNil(t, ts.objLookup)
+	assert.NotNil(t, ts.grammarLookup)
+	assert.NotNil(t, ts.responseLookup)
+
+	// Check if all predefined values are set correctly
+	assert.Equal(t, enums.ActionTypeGo, ts.cmdLookup["GO"])
+	assert.Equal(t, enums.ObjectTypeFootball, ts.objLookup["FOOTBALL"])
+	assert.Equal(t, enums.DirectionTypeNorth, ts.dirLookup["NORTH"])
+	assert.Equal(t, enums.DirObjectTypeDoor, ts.dirObjLookup["DOOR"])
+	assert.Equal(t, enums.GrammarTypeDefinitionArticle, ts.grammarLookup["THE"])
+	assert.ElementsMatch(t, []enums.ActionType{enums.ActionTypeBreak, enums.ActionTypeHit, enums.ActionTypeDamage}, ts.responseLookup[enums.ActionTypeKick])
+}
+
+func TestLookupFunctions(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	assert.Equal(t, enums.ObjectTypeFootball, ts.GetObjectType("FOOTBALL"))
+	assert.Equal(t, enums.ActionTypeGo, ts.GetActionType("GO"))
+	assert.Equal(t, enums.GrammarTypeDefinitionArticle, ts.GetGrammarType("THE"))
+	assert.Equal(t, enums.DirectionTypeNorth, ts.GetDirectionType("NORTH"))
+}
+
+func TestFishTokensKickTheBallToTheWindow(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	tokens := []string{"KICK", "THE", "BALL", "TO", "THE", "WINDOW"}
+	expectedVerb := enums.ActionTypeKick
+	expectedObj := enums.ObjectTypeFootball
+	expectedDObj := enums.DirObjectTypeWindow
+	expectedIObj := enums.ObjectTypeNone
+	expectedErr := uint8(0)
+
+	result := ts.FishTokens(tokens)
+
+	assert.Equal(t, expectedVerb, result.Verb)
+	assert.Equal(t, expectedObj, result.DirectNoun)
+	assert.Equal(t, expectedDObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
+	assert.Equal(t, expectedErr, result.ErrCode)
+}
+
+func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	tokens := []string{"OPEN", "THE", "DOOR", "WITH", "THE", "IRON", "KNIFE"}
+	expectedVerb := enums.ActionTypeOpen
+	expectedObj := enums.ObjectTypeNone
+	expectedDObj := enums.DirObjectTypeDoor
+	expectedIObj := enums.ObjectTypeKnife
+	expectedErr := uint8(0)
+
+	result := ts.FishTokens(tokens)
+
+	assert.Equal(t, expectedVerb, result.Verb)
+	assert.Equal(t, expectedObj, result.DirectNoun)
+	assert.Equal(t, expectedDObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
+	assert.Equal(t, expectedErr, result.ErrCode)
+}
+
+func TestGetResponseForVerb(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	assert.ElementsMatch(t, []enums.ActionType{enums.ActionTypeBreak, enums.ActionTypeHit, enums.ActionTypeDamage}, ts.GetResponseForVerb(enums.ActionTypeKick))
+	assert.ElementsMatch(t, []enums.ActionType{enums.ActionTypeBurn, enums.ActionTypeLight, enums.ActionTypeDamage}, ts.GetResponseForVerb(enums.ActionTypeBurn))
+}


### PR DESCRIPTION
On the main.go file I added the **NTokeniserSystem** to init the tokens when the world starts.
On the enums.go file I added the grammar type as it was missing. Was added the const, toString and toEnum.
On the system_tokeniser.go I added the grammar on **setupGrammar**, **NewTokeniserSystem** and **TokeniserSystem struct**. I also create the **NTokeniserSystem** function that will call the **NewTokeniserSystem** function upon initing the world. Lastly, I added the returns functions for the types. 