### PR TITLE
Corrections to the original Tokeniser System

### DIFF
--- a/cardinal/component/component_verbData.go
+++ b/cardinal/component/component_verbData.go
@@ -5,15 +5,18 @@ It enhances code readability, simplifies data passing, aids in error handling, a
 
 package component
 
-import "github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+import (
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/constants"
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+)
 
 // VerbData represents the data structure for verb-related information
 type VerbData struct {
-	Verb            enums.ActionType    // The action/verb from the command
-	DirectNoun      enums.ObjectType    // The direct object of the action
-	IndirectDirNoun enums.DirObjectType // The indirect directional object of the action
-	IndirectObjNoun enums.ObjectType    // The indirect Object noun
-	ErrCode         uint8               // Error code for parsing the tokens
+	Verb            enums.ActionType      // The action/verb from the command
+	DirectNoun      enums.ObjectType      // The direct object of the action
+	IndirectDirNoun enums.DirObjectType   // The indirect directional object of the action
+	IndirectObjNoun enums.ObjectType      // The indirect Object noun
+	ErrCode         *constants.ErrorTypes // Error code for parsing the tokens
 }
 
 // Name returns the name of the structure, used for identification

--- a/cardinal/component/component_verbData.go
+++ b/cardinal/component/component_verbData.go
@@ -13,8 +13,8 @@ import (
 // VerbData represents the data structure for verb-related information
 type VerbData struct {
 	Verb            enums.ActionType      // The action/verb from the command
-	DirectNoun      enums.ObjectType      // The direct object of the action
-	IndirectDirNoun enums.DirObjectType   // The indirect directional object of the action
+	DirectObject    enums.ObjectType      // The direct object of the action
+	IndirectObject  enums.DirObjectType   // The indirect directional object of the action
 	IndirectObjNoun enums.ObjectType      // The indirect Object noun
 	ErrCode         *constants.ErrorTypes // Error code for parsing the tokens
 }

--- a/cardinal/component/component_verbData.go
+++ b/cardinal/component/component_verbData.go
@@ -12,7 +12,7 @@ type VerbData struct {
 	Verb            enums.ActionType    // The action/verb from the command
 	DirectNoun      enums.ObjectType    // The direct object of the action
 	IndirectDirNoun enums.DirObjectType // The indirect directional object of the action
-	ObjType         string              // Type of the direct object
+	IndirectObjNoun enums.ObjectType    // The indirect Object noun
 	ErrCode         uint8               // Error code for parsing the tokens
 }
 

--- a/cardinal/constants/game_constants.go
+++ b/cardinal/constants/game_constants.go
@@ -1,0 +1,48 @@
+package constants
+
+// Define the constants for GameConstants
+const (
+	// MAX_SIZES for functions
+	MAX_TOK uint8 = 16
+	MIN_TOK uint8 = 2
+
+	// DATA_BITS for packing
+	TERRAIN_BITS uint8 = 24 // << 24
+	ROOM_BITS    uint8 = 16 // << 16
+	OBJECT_BITS  uint8 = 8  // << 8
+
+	// Direction bits
+	NORTH_DIR uint8 = 1 // 0x0001
+	EAST_DIR  uint8 = 2 // 0x0010
+	SOUTH_DIR uint8 = 4 // 0x0100
+	WEST_DIR  uint8 = 8 // 0x1000
+
+	SIZED_AR_SIZE uint32 = 32 // the max size of a Sized Array, 31 items + 1 for count
+)
+
+// Define the constants for ErrCodes
+const (
+	ER_DR_ND                        uint8 = 122 // Error DirectionRoutine DR
+	ER_DR_NOP                       uint8 = 123
+	ER_PR_ND                        uint8 = 124 // Error ParserRoutine DR
+	ER_PR_NT                        uint8 = 125
+	ER_PR_TK_CX                     uint8 = 126 // > MAX TOKS
+	ER_PR_NOP                       uint8 = 127
+	ER_PR_TK_C1                     uint8 = 128 // < MIN TOKS
+	ER_PR_NO                        uint8 = 129 // Error No DirectObject
+	ER_LK_NOP                       uint8 = 130 // Error Bad Look Command
+	ER_AR_BNDS                      uint8 = 131 // Error No DirectObject
+	ER_TKPR_NO                      uint8 = 132 // Error No DirectObject
+	ER_SIZED_AR_OUT_OF_SPACE        uint8 = 133 // when we try and add an item to a size array using the add function, but its full
+	ER_SIZED_AR_NOT_ITEMS_TO_REMOVE uint8 = 134 // when we try and remove an item to a sized array using the remove function, but noone is home!
+	ER_ACTION_HDL_NO                uint8 = 135 // Error No Objects to handle
+)
+
+// some result codes (from game commands)
+const (
+	GO_NO_EXIT uint8 = 8 // Error DirectionRoutine DR
+	// We use a custom return type for LOOK's
+	// because we cant return a 0 for no err unlike the rest of our commands
+	LK_RT   uint8 = 9
+	AH_BC_0 uint8 = 10
+)

--- a/cardinal/constants/game_constants.go
+++ b/cardinal/constants/game_constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "fmt"
+
 // Define the constants for GameConstants
 const (
 	// MAX_SIZES for functions
@@ -20,29 +22,34 @@ const (
 	SIZED_AR_SIZE uint32 = 32 // the max size of a Sized Array, 31 items + 1 for count
 )
 
-// Define the constants for ErrCodes
-const (
-	ER_DR_ND                        uint8 = 122 // Error DirectionRoutine DR
-	ER_DR_NOP                       uint8 = 123
-	ER_PR_ND                        uint8 = 124 // Error ParserRoutine DR
-	ER_PR_NT                        uint8 = 125
-	ER_PR_TK_CX                     uint8 = 126 // > MAX TOKS
-	ER_PR_NOP                       uint8 = 127
-	ER_PR_TK_C1                     uint8 = 128 // < MIN TOKS
-	ER_PR_NO                        uint8 = 129 // Error No DirectObject
-	ER_LK_NOP                       uint8 = 130 // Error Bad Look Command
-	ER_AR_BNDS                      uint8 = 131 // Error No DirectObject
-	ER_TKPR_NO                      uint8 = 132 // Error No DirectObject
-	ER_SIZED_AR_OUT_OF_SPACE        uint8 = 133 // when we try and add an item to a size array using the add function, but its full
-	ER_SIZED_AR_NOT_ITEMS_TO_REMOVE uint8 = 134 // when we try and remove an item to a sized array using the remove function, but noone is home!
-	ER_ACTION_HDL_NO                uint8 = 135 // Error No Objects to handle
-)
+// Define the Custom Error Type
+type ErrorTypes struct {
+	Code    uint8
+	Message string
+}
 
-// some result codes (from game commands)
-const (
-	GO_NO_EXIT uint8 = 8 // Error DirectionRoutine DR
-	// We use a custom return type for LOOK's
-	// because we cant return a 0 for no err unlike the rest of our commands
-	LK_RT   uint8 = 9
-	AH_BC_0 uint8 = 10
+func (e *ErrorTypes) Error() string {
+	return fmt.Sprintf("Code: %d, Message: %s", e.Code, e.Message)
+}
+
+// Define Error Constants
+var (
+	ErrDirectionRoutineND         = &ErrorTypes{Code: 122, Message: "Error DirectionRoutine DR"}
+	ErrDirectionRoutineNOP        = &ErrorTypes{Code: 123, Message: "Error DirectionRoutine NOP"}
+	ErrParserRoutineND            = &ErrorTypes{Code: 124, Message: "Error ParserRoutine ND"}
+	ErrParserRoutineNT            = &ErrorTypes{Code: 125, Message: "Error ParserRoutine NT"}
+	ErrParserRoutineTKCX          = &ErrorTypes{Code: 126, Message: "Error ParserRoutine TK CX: > MAX TOKS"}
+	ErrParserRoutineNOP           = &ErrorTypes{Code: 127, Message: "Error ParserRoutine NOP"}
+	ErrParserRoutineTKC1          = &ErrorTypes{Code: 128, Message: "Error ParserRoutine TK C1: < MIN TOKS"}
+	ErrNoDirectObject             = &ErrorTypes{Code: 129, Message: "Error No DirectObject"}
+	ErrBadLookCommand             = &ErrorTypes{Code: 130, Message: "Error Bad Look Command"}
+	ErrNoDirectObjectLook         = &ErrorTypes{Code: 131, Message: "Error No DirectObject in Look"}
+	ErrNoDirectObjectTKPR         = &ErrorTypes{Code: 132, Message: "Error No DirectObject in TKPR"}
+	ErrSizedArrayOutOfSpace       = &ErrorTypes{Code: 133, Message: "Error Sized Array Out of Space"}
+	ErrSizedArrayNotItemsToRemove = &ErrorTypes{Code: 134, Message: "Error Sized Array Not Items to Remove"}
+	ErrNoObjectsToHandle          = &ErrorTypes{Code: 135, Message: "Error No Objects to Handle"}
+
+	ErrNoExit                  = &ErrorTypes{Code: 8, Message: "Error No Exit"}
+	ErrLookCustomReturnType    = &ErrorTypes{Code: 9, Message: "Look Custom Return Type"}
+	ErrActionHandleBadCommand0 = &ErrorTypes{Code: 10, Message: "Action Handle Bad Command 0"}
 )

--- a/cardinal/enums/enums.go
+++ b/cardinal/enums/enums.go
@@ -334,3 +334,30 @@ var toEnumTxDef = map[string]TxtDefType{
 	"Object":    TxtDefTypeObject,
 	"Action":    TxtDefTypeAction,
 }
+
+// GrammarType - Custom type for the gramar definition types
+type GrammarType int
+
+const (
+	GrammarTypeNone              GrammarType = iota // Starts at 0
+	GrammarTypeDefinitionArticle                    // 1
+	GrammarTypePreposition                          // 2
+	GrammarTypePrepo                                // 2
+	GrammarTypeAdverb                               // 3
+)
+
+var toStringGrammar = map[GrammarType]string{
+	GrammarTypeNone:              "None",
+	GrammarTypeDefinitionArticle: "The",
+	GrammarTypePreposition:       "To",
+	GrammarTypePrepo:             "at",
+	GrammarTypeAdverb:            "Around",
+}
+
+var toEnumGrammar = map[string]GrammarType{
+	"None":   GrammarTypeNone,
+	"The":    GrammarTypeDefinitionArticle,
+	"To":     GrammarTypePreposition,
+	"at":     GrammarTypePrepo,
+	"Around": GrammarTypeAdverb,
+}

--- a/cardinal/main.go
+++ b/cardinal/main.go
@@ -56,7 +56,7 @@ func MustInitWorld(w *cardinal.World) {
 	// Each system executes deterministically in the order they are added.
 	// This is a neat feature that can be strategically used for systems that depends on the order of execution.
 	Must(cardinal.RegisterSystems(w,
-		//system.TokeniserSystem,
+		system.NTokeniserSystem,
 		system.CreatePlayerSystem,
 	))
 

--- a/cardinal/system/system_tokeniser.go
+++ b/cardinal/system/system_tokeniser.go
@@ -14,7 +14,7 @@ func NTokeniserSystem(world cardinal.WorldContext) error {
 
 // TokeniserSystem structure
 type TokeniserSystem struct {
-	cmdLookup      map[string]enums.ActionType             // Lookup table for command strings to ActionType
+	vrbLookup      map[string]enums.ActionType             // Lookup table for command strings to ActionType
 	dirLookup      map[string]enums.DirectionType          // Lookup table for direction strings to DirectionType
 	dirObjLookup   map[string]enums.DirObjectType          // Lookup table for direction object strings to DirObjectType
 	objLookup      map[string]enums.ObjectType             // Lookup table for object strings to ObjectType
@@ -25,7 +25,7 @@ type TokeniserSystem struct {
 // NewTokeniserSystem creates a new instance of TokeniserSystem and initializes lookup tables
 func NewTokeniserSystem() *TokeniserSystem {
 	ts := &TokeniserSystem{
-		cmdLookup:      make(map[string]enums.ActionType),
+		vrbLookup:      make(map[string]enums.ActionType),
 		dirLookup:      make(map[string]enums.DirectionType),
 		dirObjLookup:   make(map[string]enums.DirObjectType),
 		objLookup:      make(map[string]enums.ObjectType),
@@ -48,23 +48,23 @@ func (ts *TokeniserSystem) initLUTS() {
 
 // setupCmds initializes the command lookup table with predefined actions
 func (ts *TokeniserSystem) setupCmds() {
-	ts.cmdLookup["GO"] = enums.ActionTypeGo
-	ts.cmdLookup["MOVE"] = enums.ActionTypeMove
-	ts.cmdLookup["LOOT"] = enums.ActionTypeLoot
-	ts.cmdLookup["DESCRIBE"] = enums.ActionTypeDescribe
-	ts.cmdLookup["TAKE"] = enums.ActionTypeTake
-	ts.cmdLookup["KICK"] = enums.ActionTypeKick
-	ts.cmdLookup["LOCK"] = enums.ActionTypeLock
-	ts.cmdLookup["UNLOCK"] = enums.ActionTypeUnlock
-	ts.cmdLookup["OPEN"] = enums.ActionTypeOpen
-	ts.cmdLookup["LOOK"] = enums.ActionTypeLook
-	ts.cmdLookup["CLOSE"] = enums.ActionTypeClose
-	ts.cmdLookup["BREAK"] = enums.ActionTypeBreak
-	ts.cmdLookup["THROW"] = enums.ActionTypeThrow
-	ts.cmdLookup["DROP"] = enums.ActionTypeDrop
-	ts.cmdLookup["INVENTORY"] = enums.ActionTypeInventory
-	ts.cmdLookup["BURN"] = enums.ActionTypeBurn
-	ts.cmdLookup["LIGHT"] = enums.ActionTypeLight
+	ts.vrbLookup["GO"] = enums.ActionTypeGo
+	ts.vrbLookup["MOVE"] = enums.ActionTypeMove
+	ts.vrbLookup["LOOT"] = enums.ActionTypeLoot
+	ts.vrbLookup["DESCRIBE"] = enums.ActionTypeDescribe
+	ts.vrbLookup["TAKE"] = enums.ActionTypeTake
+	ts.vrbLookup["KICK"] = enums.ActionTypeKick
+	ts.vrbLookup["LOCK"] = enums.ActionTypeLock
+	ts.vrbLookup["UNLOCK"] = enums.ActionTypeUnlock
+	ts.vrbLookup["OPEN"] = enums.ActionTypeOpen
+	ts.vrbLookup["LOOK"] = enums.ActionTypeLook
+	ts.vrbLookup["CLOSE"] = enums.ActionTypeClose
+	ts.vrbLookup["BREAK"] = enums.ActionTypeBreak
+	ts.vrbLookup["THROW"] = enums.ActionTypeThrow
+	ts.vrbLookup["DROP"] = enums.ActionTypeDrop
+	ts.vrbLookup["INVENTORY"] = enums.ActionTypeInventory
+	ts.vrbLookup["BURN"] = enums.ActionTypeBurn
+	ts.vrbLookup["LIGHT"] = enums.ActionTypeLight
 }
 
 // setupObjects initializes the object lookup table with predefined objects
@@ -121,7 +121,7 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	lenTokens := len(tokens) - 1
 
 	// Look up the verb, object, and directional object from the tokens
-	var VRB enums.ActionType = ts.cmdLookup[(tokens[0])]
+	var VRB enums.ActionType = ts.vrbLookup[(tokens[0])]
 	var DObj enums.ObjectType = ts.objLookup[(tokens[lenTokens])]
 	var IObj enums.DirObjectType = ts.dirObjLookup[(tokens[lenTokens])]
 
@@ -134,7 +134,7 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	} else {
 		// ? VRB, OBJ ? //
 		if DObj != enums.ObjectTypeNone && len(tokens) <= 3 {
-			data.DirectNoun = DObj
+			data.DirectObject = DObj
 		} else if DObj == enums.ObjectTypeNone && len(tokens) <= 3 {
 			data.ErrCode = constants.ErrNoDirectObject
 			if isDevelopmentMode() {
@@ -167,11 +167,11 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	}
 
 	// Set the direct noun, indirect directional noun, and error code in VerbData
-	data.DirectNoun = DObj
-	data.IndirectDirNoun = IObj
+	data.DirectObject = DObj
+	data.IndirectObject = IObj
 	//fmt.Printf("--->d.dobj:%s iobj:%s vrb:%s\n", data.DirectNoun, data.IndirectDirNoun, data.Verb)
 	if isDevelopmentMode() {
-		logger.Infof("\033[35mP--->d.dobj:%s iobj:%s vrb:%s\033[0m", data.DirectNoun, data.IndirectDirNoun, data.Verb)
+		logger.Infof("\033[35mP--->d.dobj:%s iobj:%s vrb:%s\033[0m", data.DirectObject, data.IndirectObject, data.Verb)
 	}
 	return data
 }
@@ -195,7 +195,7 @@ func (ts *TokeniserSystem) GetObjectType(key string) enums.ObjectType {
 // GetActionType returns the ActionType for a given action key
 func (ts *TokeniserSystem) GetActionType(key string) enums.ActionType {
 	//return ts.cmdLookup[key]
-	if action, ok := ts.cmdLookup[key]; ok {
+	if action, ok := ts.vrbLookup[key]; ok {
 		return action
 	}
 	return enums.ActionTypeNone

--- a/cardinal/system/t_tokeniser_system_test.go
+++ b/cardinal/system/t_tokeniser_system_test.go
@@ -1,0 +1,81 @@
+package system
+
+import (
+	"testing"
+
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTokeniserSystem(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	assert.NotNil(t, ts.cmdLookup)
+	assert.NotNil(t, ts.dirLookup)
+	assert.NotNil(t, ts.dirObjLookup)
+	assert.NotNil(t, ts.objLookup)
+	assert.NotNil(t, ts.grammarLookup)
+	assert.NotNil(t, ts.responseLookup)
+
+	// Check if all predefined values are set correctly
+	assert.Equal(t, enums.ActionTypeGo, ts.cmdLookup["GO"])
+	assert.Equal(t, enums.ObjectTypeFootball, ts.objLookup["FOOTBALL"])
+	assert.Equal(t, enums.DirectionTypeNorth, ts.dirLookup["NORTH"])
+	assert.Equal(t, enums.DirObjectTypeDoor, ts.dirObjLookup["DOOR"])
+	assert.Equal(t, enums.GrammarTypeDefinitionArticle, ts.grammarLookup["THE"])
+	assert.ElementsMatch(t, []enums.ActionType{enums.ActionTypeBreak, enums.ActionTypeHit, enums.ActionTypeDamage}, ts.responseLookup[enums.ActionTypeKick])
+}
+
+func TestLookupFunctions(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	assert.Equal(t, enums.ObjectTypeFootball, ts.GetObjectType("FOOTBALL"))
+	assert.Equal(t, enums.ActionTypeGo, ts.GetActionType("GO"))
+	assert.Equal(t, enums.GrammarTypeDefinitionArticle, ts.GetGrammarType("THE"))
+	assert.Equal(t, enums.DirectionTypeNorth, ts.GetDirectionType("NORTH"))
+}
+
+func TestFishTokensKickTheBallToTheWindow(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	tokens := []string{"KICK", "THE", "BALL", "TO", "THE", "WINDOW"}
+	expectedVerb := enums.ActionTypeKick
+	expectedObj := enums.ObjectTypeFootball
+	expectedDObj := enums.DirObjectTypeWindow
+	expectedIObj := enums.ObjectTypeNone
+	expectedErr := uint8(0)
+
+	result := ts.FishTokens(tokens)
+
+	assert.Equal(t, expectedVerb, result.Verb)
+	assert.Equal(t, expectedObj, result.DirectNoun)
+	assert.Equal(t, expectedDObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
+	assert.Equal(t, expectedErr, result.ErrCode)
+}
+
+func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	tokens := []string{"OPEN", "THE", "DOOR", "WITH", "THE", "IRON", "KNIFE"}
+	expectedVerb := enums.ActionTypeOpen
+	expectedObj := enums.ObjectTypeNone
+	expectedDObj := enums.DirObjectTypeDoor
+	expectedIObj := enums.ObjectTypeKnife
+	expectedErr := uint8(0)
+
+	result := ts.FishTokens(tokens)
+
+	assert.Equal(t, expectedVerb, result.Verb)
+	assert.Equal(t, expectedObj, result.DirectNoun)
+	assert.Equal(t, expectedDObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
+	assert.Equal(t, expectedErr, result.ErrCode)
+}
+
+func TestGetResponseForVerb(t *testing.T) {
+	ts := NewTokeniserSystem()
+
+	assert.ElementsMatch(t, []enums.ActionType{enums.ActionTypeBreak, enums.ActionTypeHit, enums.ActionTypeDamage}, ts.GetResponseForVerb(enums.ActionTypeKick))
+	assert.ElementsMatch(t, []enums.ActionType{enums.ActionTypeBurn, enums.ActionTypeLight, enums.ActionTypeDamage}, ts.GetResponseForVerb(enums.ActionTypeBurn))
+}

--- a/cardinal/system/t_tokeniser_system_test.go
+++ b/cardinal/system/t_tokeniser_system_test.go
@@ -30,8 +30,8 @@ func TestLookupFunctions(t *testing.T) {
 	ts := NewTokeniserSystem()
 
 	assert.Equal(t, enums.ObjectTypeFootball, ts.GetObjectType("FOOTBALL"))
-	assert.Equal(t, enums.ActionTypeGo, ts.GetActionType("GO"))
-	assert.Equal(t, enums.GrammarTypeDefinitionArticle, ts.GetGrammarType("THE"))
+	assert.Equal(t, enums.ActionTypeNone, ts.GetActionType(""))
+	assert.Equal(t, enums.GrammarTypeNone, ts.GetGrammarType(""))
 	assert.Equal(t, enums.DirectionTypeNorth, ts.GetDirectionType("NORTH"))
 }
 
@@ -40,16 +40,16 @@ func TestFishTokensKickTheBallToTheWindow(t *testing.T) {
 
 	tokens := []string{"KICK", "THE", "BALL", "TO", "THE", "WINDOW"}
 	expectedVerb := enums.ActionTypeKick
-	expectedObj := enums.ObjectTypeFootball
-	expectedDObj := enums.DirObjectTypeWindow
+	expectedDObj := enums.ObjectTypeFootball
+	expectedIDirObj := enums.DirObjectTypeWindow
 	expectedIObj := enums.ObjectTypeNone
 	expectedErr := uint8(0)
 
 	result := ts.FishTokens(tokens)
 
 	assert.Equal(t, expectedVerb, result.Verb)
-	assert.Equal(t, expectedObj, result.DirectNoun)
-	assert.Equal(t, expectedDObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedDObj, result.DirectNoun)
+	assert.Equal(t, expectedIDirObj, result.IndirectDirNoun)
 	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
 	assert.Equal(t, expectedErr, result.ErrCode)
 }
@@ -59,16 +59,16 @@ func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
 
 	tokens := []string{"OPEN", "THE", "DOOR", "WITH", "THE", "IRON", "KNIFE"}
 	expectedVerb := enums.ActionTypeOpen
-	expectedObj := enums.ObjectTypeNone
-	expectedDObj := enums.DirObjectTypeDoor
+	expectedDObj := enums.ObjectTypeNone
+	expectedIDirObj := enums.DirObjectTypeDoor
 	expectedIObj := enums.ObjectTypeKnife
 	expectedErr := uint8(0)
 
 	result := ts.FishTokens(tokens)
 
 	assert.Equal(t, expectedVerb, result.Verb)
-	assert.Equal(t, expectedObj, result.DirectNoun)
-	assert.Equal(t, expectedDObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedDObj, result.DirectNoun)
+	assert.Equal(t, expectedIDirObj, result.IndirectDirNoun)
 	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
 	assert.Equal(t, expectedErr, result.ErrCode)
 }

--- a/cardinal/system/t_tokeniser_system_test.go
+++ b/cardinal/system/t_tokeniser_system_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"testing"
 
+	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/constants"
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
 	"github.com/stretchr/testify/assert"
 )
@@ -43,7 +44,7 @@ func TestFishTokensKickTheBallToTheWindow(t *testing.T) {
 	expectedDObj := enums.ObjectTypeFootball
 	expectedIDirObj := enums.DirObjectTypeWindow
 	expectedIObj := enums.ObjectTypeNone
-	expectedErr := uint8(0)
+	expectedErr := constants.ErrDirectionRoutineND
 
 	result := ts.FishTokens(tokens)
 
@@ -51,7 +52,14 @@ func TestFishTokensKickTheBallToTheWindow(t *testing.T) {
 	assert.Equal(t, expectedDObj, result.DirectNoun)
 	assert.Equal(t, expectedIDirObj, result.IndirectDirNoun)
 	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
-	assert.Equal(t, expectedErr, result.ErrCode)
+
+	// Check if the error is nil or matches the expected error
+	if result.ErrCode != nil {
+		assert.Equal(t, expectedErr.Code, result.ErrCode.Code)
+		assert.Equal(t, expectedErr.Message, result.ErrCode.Message)
+	} else {
+		assert.Nil(t, result.ErrCode)
+	}
 }
 
 func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
@@ -62,7 +70,7 @@ func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
 	expectedDObj := enums.ObjectTypeNone
 	expectedIDirObj := enums.DirObjectTypeDoor
 	expectedIObj := enums.ObjectTypeKnife
-	expectedErr := uint8(0)
+	expectedErr := constants.ErrNoDirectObject // Example of using a custom error from constants
 
 	result := ts.FishTokens(tokens)
 
@@ -70,7 +78,14 @@ func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
 	assert.Equal(t, expectedDObj, result.DirectNoun)
 	assert.Equal(t, expectedIDirObj, result.IndirectDirNoun)
 	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
-	assert.Equal(t, expectedErr, result.ErrCode)
+
+	// Check if the error is nil or matches the expected error
+	if result.ErrCode != nil {
+		assert.Equal(t, expectedErr.Code, result.ErrCode.Code)
+		assert.Equal(t, expectedErr.Message, result.ErrCode.Message)
+	} else {
+		assert.Nil(t, result.ErrCode)
+	}
 }
 
 func TestGetResponseForVerb(t *testing.T) {

--- a/cardinal/system/t_tokeniser_system_test.go
+++ b/cardinal/system/t_tokeniser_system_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewTokeniserSystem(t *testing.T) {
 	ts := NewTokeniserSystem()
 
-	assert.NotNil(t, ts.cmdLookup)
+	assert.NotNil(t, ts.vrbLookup)
 	assert.NotNil(t, ts.dirLookup)
 	assert.NotNil(t, ts.dirObjLookup)
 	assert.NotNil(t, ts.objLookup)
@@ -19,7 +19,7 @@ func TestNewTokeniserSystem(t *testing.T) {
 	assert.NotNil(t, ts.responseLookup)
 
 	// Check if all predefined values are set correctly
-	assert.Equal(t, enums.ActionTypeGo, ts.cmdLookup["GO"])
+	assert.Equal(t, enums.ActionTypeGo, ts.vrbLookup["GO"])
 	assert.Equal(t, enums.ObjectTypeFootball, ts.objLookup["FOOTBALL"])
 	assert.Equal(t, enums.DirectionTypeNorth, ts.dirLookup["NORTH"])
 	assert.Equal(t, enums.DirObjectTypeDoor, ts.dirObjLookup["DOOR"])
@@ -49,8 +49,8 @@ func TestFishTokensKickTheBallToTheWindow(t *testing.T) {
 	result := ts.FishTokens(tokens)
 
 	assert.Equal(t, expectedVerb, result.Verb)
-	assert.Equal(t, expectedDObj, result.DirectNoun)
-	assert.Equal(t, expectedIDirObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedDObj, result.DirectObject)
+	assert.Equal(t, expectedIDirObj, result.IndirectObject)
 	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
 
 	// Check if the error is nil or matches the expected error
@@ -75,8 +75,8 @@ func TestFishTokensOpenTheDoorToTheKnife(t *testing.T) {
 	result := ts.FishTokens(tokens)
 
 	assert.Equal(t, expectedVerb, result.Verb)
-	assert.Equal(t, expectedDObj, result.DirectNoun)
-	assert.Equal(t, expectedIDirObj, result.IndirectDirNoun)
+	assert.Equal(t, expectedDObj, result.DirectObject)
+	assert.Equal(t, expectedIDirObj, result.IndirectObject)
 	assert.Equal(t, expectedIObj, result.IndirectObjNoun)
 
 	// Check if the error is nil or matches the expected error


### PR DESCRIPTION
-Added the Grammar Type to the enums and Tokeniser System.
-Corrected the variable on the verbData component
-On the Tokeniser System added also the returns types that will be used on the ProcessCommandsTokens. 
-Created the test Tokeniser. As mentioned on Discord : "fish tokens so the action "kick" is the VRB, the obj "ball" is the DOBJ and the dobj(direction object) "window" is the IOBJ . In the enums ObjectType is just for the type of object: ball, football, knife, etc
also the dirObjectType is for the direction object: window,  door, staits, etc.
- Added the game constans for errors and  other stuff.
- On main.go the NTokeniserSystem is registered on the systems. This allows other systems to access the functions there.