### PR TITLE
Finial Logger fix

### DIFF
--- a/cardinal/constants/game_constants.go
+++ b/cardinal/constants/game_constants.go
@@ -34,6 +34,8 @@ func (e *ErrorTypes) Error() string {
 
 // Define Error Constants
 var (
+	NOERR = &ErrorTypes{Code: 0, Message: "NO ERROR"}
+
 	ErrDirectionRoutineND         = &ErrorTypes{Code: 122, Message: "Error DirectionRoutine DR"}
 	ErrDirectionRoutineNOP        = &ErrorTypes{Code: 123, Message: "Error DirectionRoutine NOP"}
 	ErrParserRoutineND            = &ErrorTypes{Code: 124, Message: "Error ParserRoutine ND"}

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -17,7 +17,6 @@ replace (
 
 require (
 	github.com/rs/zerolog v1.32.0
-	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	pkg.world.dev/world-engine/cardinal v1.4.1
 )

--- a/cardinal/go.sum
+++ b/cardinal/go.sum
@@ -217,8 +217,6 @@ github.com/secure-systems-lab/go-securesystemslib v0.7.0 h1:OwvJ5jQf9LnIAS83waAj
 github.com/secure-systems-lab/go-securesystemslib v0.7.0/go.mod h1:/2gYnlnHVQ6xeGtfIqFy7Do03K4cdCY0A/GlJLDKLHI=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -340,7 +338,6 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/cardinal/system/system_game_setup.go
+++ b/cardinal/system/system_game_setup.go
@@ -4,43 +4,18 @@ import (
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/component"
 	"github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/cardinal/enums"
 	"pkg.world.dev/world-engine/cardinal"
-
-	"github.com/sirupsen/logrus"
 )
-
-// Initialize logrus logger
-var (
-	logger = logrus.New()
-)
-
-func initLogger() {
-	// Set log level
-	logger.SetLevel(logrus.DebugLevel)
-
-	// Define a custom formatter with colors
-	formatter := &logrus.TextFormatter{
-		ForceColors:     true,
-		FullTimestamp:   true,
-		TimestampFormat: "2006-01-02 15:04:05",
-	}
-
-	logger.SetFormatter(formatter)
-}
 
 // NGameSetupSystem initializes the game setup system.
 func NGameSetupSystem(world cardinal.WorldContext) error {
 
 	setup := NewGameSetup(world)
 	setup.Init(world)
-	initLogger()
 
-	if isDevelopmentMode() {
-		// LOG FOR TESTING TxtDefStore entries
-		// Log the number of entries and contents of TxtDefStore
-		logger.Debugf("\033[34mTxtDefStore initialized with %d entries\033[0m", len(setup.TxtDefStore.TxtDefs))
-		for key, value := range setup.TxtDefStore.TxtDefs {
-			logger.Debugf("\033[34mTxtDefStore entry - Key: %s, Value: %+v\033[0m", key, value)
-		}
+	// Log the number of entries and contents of TxtDefStore
+	world.Logger().Debug().Msgf("TxtDefStore initialized with %d entries\033[0m", len(setup.TxtDefStore.TxtDefs))
+	for key, value := range setup.TxtDefStore.TxtDefs {
+		world.Logger().Debug().Msgf("TxtDefStore entry - Key: %s, Value: %+v\033[0m", key, value)
 	}
 
 	return nil
@@ -326,15 +301,8 @@ func (s *GameSetup) createPlace(roomID uint32, roomType enums.RoomType, dObjs [3
 
 	// Check for errors during entity creation
 	if err != nil {
-		world.Logger().Debug().Msgf("Failed to create entity for room with ID %d: %v", roomID, err)
+		world.Logger().Error().Msgf("Failed to create entity for room with ID %d: %v", roomID, err)
 	}
 
-	world.Logger().Debug().Msgf("Room with ID %d created successfully, entity ID: %d", roomID, entityID)
-
-}
-
-// isDevelopmentMode returns true if the application is running in development/debug mode.
-func isDevelopmentMode() bool {
-
-	return false // Change this based on if you run in dev or production.
+	world.Logger().Info().Msgf("Room with ID %d created successfully, entity ID: %d", roomID, entityID)
 }

--- a/cardinal/system/system_meat_puppet_system.go
+++ b/cardinal/system/system_meat_puppet_system.go
@@ -40,7 +40,7 @@ func ProcessCommandsTokens(world cardinal.WorldContext) error {
 
 			// we have gone through the TOKENS, give err feedback if needed
 			if er != 0 {
-				world.Logger().Debug().Msgf("---->PCE: PCR_ERR: %v:\033[0m", er)
+				world.Logger().Error().Msgf("---->PCE: PCR_ERR: %v:\033[0m", er)
 				var errMsg string
 				errMsg = insultMeat(er, "")
 				// HERE GOES OUTPUT SET
@@ -61,7 +61,11 @@ func ProcessCommandsTokens(world cardinal.WorldContext) error {
 
 			world.Logger().Debug().Msg("---->Processing tokens completed")
 
-			ts.FishTokens(messageData.Msg.Tokens)
+			verbData := ts.FishTokens(messageData.Msg.Tokens)
+			world.Logger().Debug().Msgf("P--->d.dobj:%s iobj:%s vrb:%s", verbData.DirectObject, verbData.IndirectObject, verbData.Verb)
+			if verbData.ErrCode != constants.NOERR {
+				world.Logger().Error().Msgf("E---err:%s", verbData.ErrCode)
+			}
 
 			return msg.ProcessCommandsReply{
 				Success: true,
@@ -79,7 +83,7 @@ func getPlayerEntity(world cardinal.WorldContext, pEID types.EntityID) (componen
 		Each(world, func(id types.EntityID) bool {
 			player, err := cardinal.GetComponent[component.Player](world, id)
 			if err != nil {
-				world.Logger().Debug().Msgf("GetPlayerEntity: Error getting Player Component: %v", err)
+				world.Logger().Error().Msgf("GetPlayerEntity: Error getting Player Component: %v", err)
 				return true
 			}
 

--- a/cardinal/system/system_tokeniser.go
+++ b/cardinal/system/system_tokeniser.go
@@ -128,13 +128,11 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	var IObj enums.ObjectType = ts.objLookup[(tokens[lenTokens])]
 
 	data.Verb = VRB // Set the verb in VerbData
+	data.ErrCode = constants.NOERR
 
 	switch {
 	case DObj == enums.ObjectTypeNone && IObj == enums.ObjectTypeNone:
 		data.ErrCode = constants.ErrNoDirectObject
-		if isDevelopmentMode() {
-			logger.Errorf("\033[31mE--->1err:%s\033[0m", data.ErrCode)
-		}
 	case len(tokens) <= 3:
 		switch {
 		case DObj != enums.ObjectTypeNone:
@@ -142,9 +140,6 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 			IObj = enums.ObjectTypeNone
 		case DObj == enums.ObjectTypeNone:
 			data.ErrCode = constants.ErrNoDirectObject
-			if isDevelopmentMode() {
-				logger.Errorf("\033[31mE--->2err:%s\033[0m", data.ErrCode)
-			}
 		}
 	case len(tokens) > 3:
 		switch {
@@ -155,9 +150,6 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 				DObj = ts.objLookup[tokens[2]]
 				if DObj == enums.ObjectTypeNone {
 					data.ErrCode = constants.ErrNoDirectObject
-					if isDevelopmentMode() {
-						logger.Errorf("\033[31mE--->3err:%s\033[0m", data.ErrCode)
-					}
 				}
 			}
 		case DObj != enums.ObjectTypeNone:
@@ -172,9 +164,7 @@ func (ts *TokeniserSystem) FishTokens(tokens []string) component.VerbData {
 	// Set the direct noun, indirect directional noun, and error code in VerbData
 	data.DirectObject = DObj
 	data.IndirectObject = IObj
-	if isDevelopmentMode() {
-		logger.Infof("\033[35mP--->d.dobj:%s iobj:%s vrb:%s\033[0m", data.DirectObject, data.IndirectObject, data.Verb)
-	}
+	//world.Logger().Debug().Msgf("P--->d.dobj:%s iobj:%s vrb:%s\033[0m", data.DirectObject, data.IndirectObject, data.Verb)
 	return data
 }
 

--- a/cardinal/system/t_create_player_system_test.go
+++ b/cardinal/system/t_create_player_system_test.go
@@ -124,9 +124,6 @@ func createNewPlayerTest(playerName string, createEntity func(entity interface{}
 	// Create a new player entity.
 	playerManagerID, err := createEntity(&component.Player{})
 	if err != nil {
-		if isDevelopmentMode() {
-			logger.Errorf("\033[31mFailed to create player entity: %v\033[0m", err)
-		}
 		return 0, err
 	}
 
@@ -150,9 +147,6 @@ func assignPlayerToRoomTest(playerID uint32, roomID types.EntityID, getRoom getR
 	// Get the Room based on the roomID.
 	selectedRoom, err := getRoom(roomID)
 	if err != nil {
-		if isDevelopmentMode() {
-			logger.Errorf("\033[31mFailed to retrieve room component: %v\033[0m", err)
-		}
 		return err
 	}
 
@@ -166,9 +160,6 @@ func assignPlayerToRoomTest(playerID uint32, roomID types.EntityID, getRoom getR
 
 	// Update the room entity.
 	if err := setRoom(roomID, selectedRoom); err != nil {
-		if isDevelopmentMode() {
-			logger.Errorf("\033[31mFailed to update room component: %v\033[0m", err)
-		}
 		return err
 	}
 
@@ -179,17 +170,11 @@ func assignPlayerToRoomTest(playerID uint32, roomID types.EntityID, getRoom getR
 func updatePlayerRoomIDTest(playerManagerID types.EntityID, roomID types.EntityID, getPlayer getPlayerFunc, setPlayer setPlayerFunc) error {
 	playerManager, err := getPlayer(playerManagerID)
 	if err != nil {
-		if isDevelopmentMode() {
-			logger.Errorf("\033[31mError getting Player Component: %v\033[0m", err)
-		}
 		return err
 	}
 
 	playerManager.RoomID = uint32(roomID)
 	if err := setPlayer(playerManagerID, playerManager); err != nil {
-		if isDevelopmentMode() {
-			logger.Errorf("\033[31mError updating the Player entity: %v\033[0m", err)
-		}
 		return err
 	}
 


### PR DESCRIPTION
-Final change of logger type on the rest of files.
-Elimination of the `IsDevelopment` method as  well the `initLogger` method as they are no longer needed.
-Adjusted the logger for when its done fishing the tokens.  On the Meat Puppet system it will debug the Dobject the Iobject and the verb. In case the err code is different from the value when there is no error code, it will log an error indicating which is the error. This was just of optimization of the log. 
-As it is no longer needed the logrus import for the logs, it was removed and therefore the go.mod and go.sum were updated through the command `go mod tidy` as it was require. 