### PR TITLE
Look System Correction of objects and dirObjects when init world. Get obj and dir…

### DIFF
--- a/cardinal/component/component_object.go
+++ b/cardinal/component/component_object.go
@@ -5,13 +5,13 @@ import (
 )
 
 type Object struct {
-	ObjectID        uint32 `json:"id"`
-	ObjectName      string
+	ObjectID        uint32              `json:"id"`
+	ObjectName      string              `json:"object_name"`
 	ObjectType      enums.ObjectType    `json:"object_type"`
 	MaterialType    enums.MaterialType  `json:"material_type"`
 	DirType         enums.DirectionType `json:"dir_type"`
 	DestID          enums.RoomType      `json:"dest_id"`
-	TxtDefID        string              `json:"txt_def_id"`
+	Description     string              `json:"description"`
 	ObjectActionIDs [32]uint32          `json:"object_action_ids"`
 }
 

--- a/cardinal/component/component_room.go
+++ b/cardinal/component/component_room.go
@@ -8,8 +8,8 @@ type Room struct {
 	ID          uint32         `json:"id"`
 	Description string         `json:"description"`
 	RoomType    enums.RoomType `json:"room_type"`
-	ObjectIDs   [32]uint32     `json:"object_ids"`
-	DirObjIDs   [32]uint32     `json:"dir_obj_ids"`
+	Objects     map[int]Object `json:"object_ids"`
+	DirObjs     map[int]Object `json:"dir_obj_ids"`
 	Players     [32]uint32     `json:"players"`
 }
 

--- a/cardinal/system/system_game_setup.go
+++ b/cardinal/system/system_game_setup.go
@@ -69,7 +69,7 @@ func (s *GameSetup) setupPlain(world cardinal.WorldContext) {
 		"you can actually smell fart", true, true, true, 0, 0)
 
 	plainBarn := [32]uint32{open2Barn}
-	dObjs := [32]uint32{s.createDirObject(enums.DirectionTypeNorth, enums.RoomTypePlain,
+	dObjs := []component.Object{s.createDirObject(enums.DirectionTypeNorth, enums.RoomTypePlain,
 		enums.ObjectTypePath, enums.MaterialTypeDirt,
 		"path", plainBarn, world)}
 
@@ -77,19 +77,17 @@ func (s *GameSetup) setupPlain(world cardinal.WorldContext) {
 		"your nose is really itchy", true, true, true, 0, 0)
 
 	plainPath := [32]uint32{open2Path}
-	dObjs[1] = s.createDirObject(enums.DirectionTypeEast, enums.RoomTypeWoodCabin,
+	dObjs = append(dObjs, s.createDirObject(enums.DirectionTypeEast, enums.RoomTypeWoodCabin,
 		enums.ObjectTypePath, enums.MaterialTypeMud,
-		"path", plainPath, world)
+		"path", plainPath, world))
 
 	kick := s.createAction(enums.ActionTypeKick, "the ball (such as it is)\n"+
 		"bounces feebly\n then rolls into some fresh dog eggs\n"+
 		"none the less you briefly feel a little better", true, false, true, 0, 0)
 
 	ballActions := [32]uint32{kick}
-	objs := [32]uint32{s.createObject(enums.ObjectTypeFootball, enums.MaterialTypeFlesh,
-		"A slightly deflated knock off uefa football,\n"+
-			"not quite spherical, it's "+
-			"kickable though", "football", ballActions, world)}
+	objs := []component.Object{s.createObject(enums.ObjectTypeFootball, enums.MaterialTypeFlesh,
+		"A slightly deflated knock off uefa football, not quite spherical, it's kickable though.", "football", ballActions, world)}
 
 	roomID := s.RoomStore.Add(component.Room{
 		Description: "a windswept plain",
@@ -97,18 +95,17 @@ func (s *GameSetup) setupPlain(world cardinal.WorldContext) {
 	})
 
 	tidPlain := s._textGuid("a windsept plain")
-	s.TxtDefStore.Set(tidPlain, enums.TxtDefTypePlace, "the wind blowing is cold and\n"+
-		"bison skulls in piles taller than houses\n"+
-		"cover the plains as far as your eye can see\n"+
-		"the air tastes of burnt grease and bensons.",
-	)
+	tidPlain += " " + ("where the wind blowing is cold and" +
+		" bison skulls in piles taller than houses" +
+		" cover the plains as far as your eye can see" +
+		" the air tastes of burnt grease and bensons.")
 
 	// Logs to verify the ID's in the setup
 	world.Logger().Debug().Msgf("Object IDs for room %d: %v\033[0m", roomID, objs)
 	world.Logger().Debug().Msgf("Directional Object IDs for room %d: %v", roomID, dObjs)
 
 	// Inspect Data Passed to Setup Functions
-	world.Logger().Debug().Msgf("ata passed to createPlace for room %d: %+v\033[0m", roomID, objs)
+	world.Logger().Debug().Msgf("Data passed to createPlace for room %d: %+v\033[0m", roomID, objs)
 	world.Logger().Debug().Msgf("Data passed to createDirectionalObject for room %d: %+v\033[0m", roomID, dObjs)
 
 	s.createPlace(roomID, enums.RoomTypePlain, dObjs, objs, tidPlain, world)
@@ -123,7 +120,7 @@ func (s *GameSetup) setupBarn(world cardinal.WorldContext) {
 	// KBARN -> S
 	open2South := s.createAction(enums.ActionTypeOpen, "the door opens\n", true, true, true, 0, 0)
 	barnPlain := [32]uint32{open2South}
-	dObjs := [32]uint32{s.createDirObject(enums.DirectionTypeSouth, enums.RoomTypePlain,
+	dObjs := []component.Object{s.createDirObject(enums.DirectionTypeSouth, enums.RoomTypePlain,
 		enums.ObjectTypeDoor, enums.MaterialTypeWood,
 		"door", barnPlain, world)}
 
@@ -131,14 +128,14 @@ func (s *GameSetup) setupBarn(world cardinal.WorldContext) {
 		"falls open", false, false, false, 0, 0)
 
 	smashWindow := s.createAction(enums.ActionTypeBreak, "I love the sound of breaking glass\n"+
-		"especially when I'm lonely , the panes and the frame shatter\n"+
+		"especially when I'm lonely, the panes and the frame shatter\n"+
 		"satisfyingly spreading broken joy on the floor",
 		true, false, false, open2Forest, 0)
 
 	windowActions := [32]uint32{open2Forest, smashWindow}
-	dObjs[1] = s.createDirObject(enums.DirectionTypeEast, enums.RoomTypeForge,
+	dObjs = append(dObjs, s.createDirObject(enums.DirectionTypeEast, enums.RoomTypeForge,
 		enums.ObjectTypeWindow, enums.MaterialTypeWood,
-		"window", windowActions, world)
+		"window", windowActions, world))
 
 	roomID := s.RoomStore.Add(component.Room{
 		Description: "a barn",
@@ -146,11 +143,9 @@ func (s *GameSetup) setupBarn(world cardinal.WorldContext) {
 	})
 
 	tidBarn := s._textGuid("a barn")
-	s.TxtDefStore.Set(tidBarn, enums.TxtDefTypePlace,
-		"The place is dusty and full of spiderwebs,\n"+
-			"something died in here, possibly your own self\n"+
-			"plenty of corners and dark shadows",
-	)
+	tidBarn += (". The place is dusty and full of spiderwebs," +
+		" something died in here, possibly your own self" +
+		" plenty of corners and dark shadows")
 
 	// Logs to verify the ID's in the setup
 	world.Logger().Debug().Msgf("Object IDs for room %d: %v\033[0m", roomID, [32]uint32{})
@@ -160,7 +155,7 @@ func (s *GameSetup) setupBarn(world cardinal.WorldContext) {
 	world.Logger().Debug().Msgf("ata passed to createPlace for room %d: %+v\033[0m", roomID, [32]uint32{})
 	world.Logger().Debug().Msgf("Data passed to createDirectionalObject for room %d: %+v\033[0m", roomID, dObjs)
 
-	s.createPlace(roomID, enums.RoomTypeWoodCabin, dObjs, [32]uint32{}, tidBarn, world) // Pass empty array instead of nil for the objects.
+	s.createPlace(roomID, enums.RoomTypeWoodCabin, dObjs, nil, tidBarn, world) // Pass empty array instead of nil for the objects.
 
 	world.Logger().Debug().Msg("---->Barn setup complete")
 
@@ -174,7 +169,7 @@ func (s *GameSetup) setupMountainPath(world cardinal.WorldContext) {
 	open2West := s.createAction(enums.ActionTypeOpen, "the path is passable", true, true, false, 0, 0)
 	pathActions := [32]uint32{open2West}
 
-	dObjs := [32]uint32{s.createDirObject(enums.DirectionTypeWest, enums.RoomTypePlain,
+	dObjs := []component.Object{s.createDirObject(enums.DirectionTypeWest, enums.RoomTypePlain,
 		enums.ObjectTypePath, enums.MaterialTypeStone,
 		"path", pathActions, world)}
 
@@ -184,13 +179,11 @@ func (s *GameSetup) setupMountainPath(world cardinal.WorldContext) {
 	})
 
 	tidMpath := s._textGuid("a high mountain pass")
-	s.TxtDefStore.Set(tidMpath, enums.TxtDefTypePlace,
-		"it winds through the mountains, the path is treacherous\n"+
-			"toilet papered trees cover the steep \n valley sides below you.\n"+
-			"On closer inspection the TP might \nbe the remains of a cricket team\n"+
-			"or perhaps a lost and very dead KKK picnic group.\n"+
-			"It's brass monkeys.",
-	)
+	tidMpath += " " + ("where it winds through the mountains, the path is treacherous" +
+		" toilet papered trees cover the steep valley sides below you." +
+		" On closer inspection the TP might \nbe the remains of a cricket team" +
+		" or perhaps a lost and very dead KKK picnic group." +
+		" It's brass monkeys.")
 
 	// Logs to verify the ID's in the setup
 	world.Logger().Debug().Msgf("Object IDs for room %d: %v\033[0m", roomID, [32]uint32{})
@@ -200,14 +193,14 @@ func (s *GameSetup) setupMountainPath(world cardinal.WorldContext) {
 	world.Logger().Debug().Msgf("ata passed to createPlace for room %d: %+v\033[0m", roomID, [32]uint32{})
 	world.Logger().Debug().Msgf("Data passed to createDirectionalObject for room %d: %+v\033[0m", roomID, dObjs)
 
-	s.createPlace(roomID, enums.RoomTypeStoneCabin, dObjs, [32]uint32{}, tidMpath, world) // Pass empty array instead of nil for the objects.
+	s.createPlace(roomID, enums.RoomTypeStoneCabin, dObjs, nil, tidMpath, world) // Pass empty array instead of nil for the objects.
 
 	world.Logger().Debug().Msg("---->Mountain path setup complete")
 }
 
 // createDirObject creates a directional object in the game world.
 func (s *GameSetup) createDirObject(dirType enums.DirectionType, dstID enums.RoomType, dOType enums.ObjectType,
-	mType enums.MaterialType, desc string, actionObjects [32]uint32, world cardinal.WorldContext) uint32 {
+	mType enums.MaterialType, desc string, actionObjects [32]uint32, world cardinal.WorldContext) component.Object {
 	// Generate a text GUID for the description
 	txtID := s._textGuid(desc)
 
@@ -220,7 +213,7 @@ func (s *GameSetup) createDirObject(dirType enums.DirectionType, dstID enums.Roo
 		DestID:          dstID,
 		ObjectType:      dOType,
 		MaterialType:    mType,
-		TxtDefID:        txtID,
+		Description:     txtID,
 		ObjectActionIDs: actionObjects,
 	}
 
@@ -233,12 +226,12 @@ func (s *GameSetup) createDirObject(dirType enums.DirectionType, dstID enums.Roo
 	world.Logger().Debug().Msgf("Directional object created - ID: %d, Type: %s, Destination Room Type: %s, Material: %s, Description: %s",
 		dirObjID, dirType, dstID, mType, desc)
 
-	return dirObjID
+	return directionObjData
 }
 
 // createObject creates an object in the game world.
 func (s *GameSetup) createObject(objType enums.ObjectType, mType enums.MaterialType, desc, objName string,
-	actionObjects [32]uint32, world cardinal.WorldContext) uint32 {
+	actionObjects [32]uint32, world cardinal.WorldContext) component.Object {
 
 	// Generate a text GUID for the description
 	txtID := s._textGuid(desc)
@@ -251,7 +244,7 @@ func (s *GameSetup) createObject(objType enums.ObjectType, mType enums.MaterialT
 		ObjectName:      objName,
 		ObjectType:      objType,
 		MaterialType:    mType,
-		TxtDefID:        txtID,
+		Description:     desc,
 		ObjectActionIDs: actionObjects,
 	}
 
@@ -263,7 +256,7 @@ func (s *GameSetup) createObject(objType enums.ObjectType, mType enums.MaterialT
 
 	world.Logger().Debug().Msgf("Object created - ID: %d, Type: %s, Material: %s, Description: %s", objID, objType, mType, desc)
 
-	return objID
+	return objData
 }
 
 // createAction creates an action in the game world.
@@ -287,15 +280,15 @@ func (s *GameSetup) _textGuid(desc string) string {
 }
 
 // createPlace creates a room in the game world and populates it with objects and directional objects.
-func (s *GameSetup) createPlace(roomID uint32, roomType enums.RoomType, dObjs [32]uint32, objs [32]uint32, tid string, world cardinal.WorldContext) {
+func (s *GameSetup) createPlace(roomID uint32, roomType enums.RoomType, dObjs []component.Object, objs []component.Object, tid string, world cardinal.WorldContext) {
 	// Create an entity representing the room with its components
-	entityID, err := cardinal.Create(s.worldCtx,
+	roomManagerID, err := cardinal.Create(s.worldCtx,
 		component.Room{
 			ID:          roomID - 1,
 			Description: tid,
 			RoomType:    roomType,
-			ObjectIDs:   objs,  // Populate ObjectIDs with the IDs of objects
-			DirObjIDs:   dObjs, // Populate DirObjIDs with the IDs of directional objects
+			Objects:     make(map[int]component.Object),
+			DirObjs:     make(map[int]component.Object),
 		},
 	)
 
@@ -304,5 +297,24 @@ func (s *GameSetup) createPlace(roomID uint32, roomType enums.RoomType, dObjs [3
 		world.Logger().Error().Msgf("Failed to create entity for room with ID %d: %v", roomID, err)
 	}
 
-	world.Logger().Info().Msgf("Room with ID %d created successfully, entity ID: %d", roomID, entityID)
+	roomManager, err := cardinal.GetComponent[component.Room](world, roomManagerID)
+	if err != nil {
+		world.Logger().Error().Msgf("Error getting Object Component: %v", err)
+	}
+
+	//Populate Objects map with the objects passed. Uses as identifier the object ID
+	for _, Obj := range objs {
+		if Obj.ObjectID != 0 {
+			roomManager.Objects[int(Obj.ObjectID)] = Obj
+		}
+	}
+
+	// Populate DirObjs map with the directional objects passed. Uses as identifier the Object ID
+	for _, dirObj := range dObjs {
+		if dirObj.ObjectID != 0 {
+			roomManager.DirObjs[int(dirObj.ObjectID)] = dirObj
+		}
+	}
+
+	world.Logger().Info().Msgf("Room with ID %d created successfully, entity ID: %d", roomID, roomManagerID)
 }

--- a/cardinal/system/system_look_system.go
+++ b/cardinal/system/system_look_system.go
@@ -53,6 +53,7 @@ func lookAround(rId uint32, playerId uint32, world cardinal.WorldContext) uint8 
 	return 0
 }
 
+// Generates the description on that will be shown
 func genDescText(playerId uint32, id uint32, world cardinal.WorldContext) string {
 
 	desc := "You are standing "
@@ -67,9 +68,14 @@ func genDescText(playerId uint32, id uint32, world cardinal.WorldContext) string
 	} else {
 		desc += fmt.Sprintf("in %s\n", room.Description)
 	}
+
+	desc += " " + ObjectDescription(room, world)
+	desc += " " + DirObjectDescription(room, world)
+
 	return desc
 }
 
+// Gets the room
 func getRoom(rID types.EntityID, world cardinal.WorldContext) (component.Room, error) {
 	var exisingRoom component.Room
 	err := cardinal.NewSearch().Entity(filter.Exact(filter.Component[component.Room]())).
@@ -89,4 +95,40 @@ func getRoom(rID types.EntityID, world cardinal.WorldContext) (component.Room, e
 		})
 
 	return exisingRoom, err
+}
+
+// Gets the Objects descriptions that exists on the room
+func ObjectDescription(room component.Room, world cardinal.WorldContext) string {
+	var object component.Object
+	var description string
+
+	for _, lookingObject := range room.Objects {
+		if lookingObject.ObjectID != 0 {
+			object = room.Objects[int(lookingObject.ObjectID)]
+			description = fmt.Sprintf("You see a %s", object.Description)
+
+			world.Logger().Debug().Msgf("Descriptions for object with ID: %d is: %v", lookingObject.ObjectID, description)
+		}
+	}
+
+	return description
+
+}
+
+// Gets the DirectionalObjects descriptions that exists on the room
+func DirObjectDescription(room component.Room, world cardinal.WorldContext) string {
+	var dirObject component.Object
+	var description string
+
+	for _, lookingDirObject := range room.DirObjs {
+		if lookingDirObject.ObjectID != 0 {
+			dirObject = room.DirObjs[int(lookingDirObject.ObjectID)]
+			description = fmt.Sprintf("You see a %s", dirObject.Description)
+
+			world.Logger().Debug().Msgf("Descriptions for dirObject with ID: %d is: %v", lookingDirObject.ObjectID, description)
+		}
+	}
+
+	return description
+
 }

--- a/cardinal/system/t_game_setup_system_test.go
+++ b/cardinal/system/t_game_setup_system_test.go
@@ -163,7 +163,7 @@ func (s *GameSetupTest) createDirObjectTest(dirType enums.DirectionType, dstID e
 		DestID:          dstID,
 		ObjectType:      dOType,
 		MaterialType:    mType,
-		TxtDefID:        txtID,
+		Description:     txtID,
 		ObjectActionIDs: actionObjects,
 	}
 	dirObjID := s.ObjectStore.Add(directionObjData)
@@ -172,12 +172,12 @@ func (s *GameSetupTest) createDirObjectTest(dirType enums.DirectionType, dstID e
 }
 
 func (s *GameSetupTest) createObjectTest(objType enums.ObjectType, mType enums.MaterialType, desc, objName string, actionObjects [32]uint32) uint32 {
-	txtID := s._textGuidTest(desc)
-	s.TxtDefStore.Set(txtID, enums.TxtDefTypeObject, desc)
+	txt := s._textGuidTest(desc)
+	s.TxtDefStore.Set(txt, enums.TxtDefTypeObject, desc)
 	objData := component.Object{
 		ObjectType:      objType,
 		MaterialType:    mType,
-		TxtDefID:        txtID,
+		Description:     txt,
 		ObjectActionIDs: actionObjects,
 		ObjectName:      objName,
 	}
@@ -197,14 +197,14 @@ func (s *GameSetupTest) _textGuidTest(desc string) string {
 	return "txt-" + desc
 }
 
-func (s *GameSetupTest) createPlaceTest(roomID uint32, roomType enums.RoomType, dObjs [32]uint32, objs [32]uint32, tid string) {
+func (s *GameSetupTest) createPlaceTest(roomID uint32, roomType enums.RoomType, dObjs []component.Object, objs []component.Object, tid string) {
 	entityID, err := cardinal.Create(s.worldCtx,
 		component.Room{
 			ID:          roomID,
 			Description: tid,
 			RoomType:    roomType,
-			ObjectIDs:   objs,
-			DirObjIDs:   dObjs,
+			Objects:     make(map[int]component.Object),
+			DirObjs:     make(map[int]component.Object),
 		},
 	)
 	if err != nil {
@@ -213,13 +213,13 @@ func (s *GameSetupTest) createPlaceTest(roomID uint32, roomType enums.RoomType, 
 	log.Printf("Room with ID %d created successfully, entity ID: %d", roomID, entityID)
 	objDescriptions := make([]string, 0, len(objs))
 	for _, objID := range objs {
-		objDef, _ := s.TxtDefStore.Get(fmt.Sprintf("%d", objID))
+		objDef, _ := s.TxtDefStore.Get(fmt.Sprintf("%v", objID))
 		objDescriptions = append(objDescriptions, objDef.Description)
 	}
 	log.Printf("Objects added to the room: %v", objDescriptions)
 	dirObjDescriptions := make([]string, 0, len(dObjs))
 	for _, dirObjID := range dObjs {
-		dirObjDef, _ := s.TxtDefStore.Get(fmt.Sprintf("%d", dirObjID))
+		dirObjDef, _ := s.TxtDefStore.Get(fmt.Sprintf("%v", dirObjID))
 		dirObjDescriptions = append(dirObjDescriptions, dirObjDef.Description)
 	}
 	log.Printf("Directional objects added to the room: %v", dirObjDescriptions)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   nakama:
     platform: linux/amd64
-    image: us-docker.pkg.dev/argus-labs/world-engine/relay/nakama:v1.2.5
+    image: ghcr.io/argus-labs/world-engine-nakama:1.2.5
     container_name: nakama
     depends_on:
       nakama-db:


### PR DESCRIPTION
-On the **Object** component changed the variable's name
-On the **Room** component changed the type of variable for the Object and Directional Object, By using maps of their type it's possible to access them and interact later on.
-On the **system_game_setup** file I adjusted the creation of the objects and directional objects so that they are created as components and then added to the room once the maps have been made. Also adjusted some format for the texts as it appeared with errors.
-On the **t_system_game_setup_test** I adjusted the variables types so that the tests can be done.
-On the **system_look_system** file I added the `ObjectDescription` and `DirObjectDescription` functions that will return the description of all the objects that exists on the maps.
-On the **docker-compose.yml** file I corrected the problem with the version of the image.  The image "link" can be found on the same file on the starter template from WE.

I'm still working on the tests. As I'm using the test utility that Scott mentioned it seems it will be possible to have only one file for all the tests.  I'll try to upload that tomorrow.

Screenshots of everything working:
- Room with object and directional objects 
![image](https://github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/assets/72756999/f22852da-e362-46d5-8877-d818e6900ab0)

- Room with only directional objects:
![image](https://github.com/ArchetypalTech/TheOrugginTrail-ArgusWE/assets/72756999/b9a36094-7146-4a1d-8e1e-bad50e92cc70)

The composition of the rooms (what objects and directional objects) is the same as the one done on MUD
